### PR TITLE
Basic API

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,4 +5,5 @@ exclude =
     __pycache__,
     build/,
     pdk/
-    venv/
+    venv/,
+    volare/__init__.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v2
       - name: Install Linters
-        run: make venv-dev
+        run: make venv
       - name: Lint
         run: make lint
   push_to_pypi:
@@ -35,12 +35,9 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.6
-      - name: Install Build Dependencies
+      - name: Build Distribution
         run: |
-          python3 -m pip install build
-      - name: Build
-        run: |
-          python3 -m build --sdist --wheel --outdir dist/ .
+          make dist
       - name: Set default for env.NEW_TAG
         run: echo "NEW_TAG=NO_NEW_TAG" >> $GITHUB_ENV
       - name: Check for new version

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,21 @@
-FILE=./requirements.txt
+FILE=./requirements_dev.txt
 
-.PHONY: venv-dev venv
-venv-dev: FILE=./requirements_dev.txt
-venv-dev: venv
-venv:
+all: dist
+
+.PHONY: dist
+dist: venv/created
+	./setup.py sdist bdist_wheel
+
+venv: venv/created
+venv/created: $(FILE)
 	rm -rf venv
 	python3 -m venv ./venv
 	./venv/bin/python3 -m pip install wheel
 	./venv/bin/python3 -m pip install -r $(FILE)
+	touch venv/created
 
 .PHONY: lint
-lint:
+lint: venv/created
 	./venv/bin/black --check .
 	./venv/bin/flake8 .
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,12 @@ all: dist
 
 .PHONY: dist
 dist: venv/created
-	./setup.py sdist bdist_wheel
+	./venv/bin/python3 setup.py sdist bdist_wheel
+
+.PHONY: lint
+lint: venv/created
+	./venv/bin/black --check .
+	./venv/bin/flake8 .
 
 venv: venv/created
 venv/created: $(FILE)
@@ -13,11 +18,6 @@ venv/created: $(FILE)
 	./venv/bin/python3 -m pip install wheel
 	./venv/bin/python3 -m pip install -r $(FILE)
 	touch venv/created
-
-.PHONY: lint
-lint: venv/created
-	./venv/bin/black --check .
-	./venv/bin/flake8 .
 
 .PHONY: veryclean
 veryclean: clean

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from setuptools import setup, find_packages
 
 from volare import __version__

--- a/volare/__init__.py
+++ b/volare/__init__.py
@@ -1,1 +1,17 @@
-__version__ = "0.1.2"
+# Copyright 2022 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+__version__ = "0.1.3"
+
+from .manage import enable
+from .build import build

--- a/volare/build.py
+++ b/volare/build.py
@@ -20,6 +20,7 @@ import pathlib
 import tarfile
 import tempfile
 import subprocess
+from typing import Optional, List
 from concurrent.futures import ThreadPoolExecutor
 
 import rich
@@ -369,12 +370,13 @@ def install_sky130(build_directory, pdk_root, version):
 
 # ---
 def build(
-    pdk_root,
-    version,
-    jobs=1,
-    sram=True,
-    clear_build_artifacts=True,
-    include_libraries=None,
+    pdk_root: str,
+    pdk: str,
+    version: str,
+    jobs: int = 1,
+    sram: bool = True,
+    clear_build_artifacts: bool = True,
+    include_libraries: Optional[List[str]] = None,
 ):
     if include_libraries is None:
         include_libraries = SKY130_DEFAULT_LIBRARIES
@@ -422,6 +424,7 @@ def build_cmd(
     version = check_version(version, tool_metadata_file_path, rich.console.Console())
     build(
         pdk_root=pdk_root,
+        pdk="sky130",
         version=version,
         jobs=jobs,
         sram=sram,

--- a/volare/common.py
+++ b/volare/common.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import os
 import json
 import requests

--- a/volare/manage.py
+++ b/volare/manage.py
@@ -134,12 +134,13 @@ def path_cmd(pdk_root, version):
 
 
 def enable(
-    pdk_root,
-    version,
+    pdk_root: str,
+    pdk: str,
+    version: str,
     build_if_not_found=False,
     also_push=False,
-    build_kwargs={},
-    push_kwargs={},
+    build_kwargs: dict = {},
+    push_kwargs: dict = {},
 ):
     console = rich.console.Console()
 
@@ -158,11 +159,10 @@ def enable(
         link = get_link_of(version)
         status = requests.head(link).status_code
         if status == 404:
+            console.print(f"Version {version} not found either locally or remotely.")
             if build_if_not_found:
-                console.print(
-                    f"Version {version} not found either locally or remotely. Will attempt to build."
-                )
-                build(pdk_root=pdk_root, version=version, **build_kwargs)
+                console.print("Attempting to build...")
+                build(pdk_root=pdk_root, pdk=pdk, version=version, **build_kwargs)
                 if also_push:
                     push(pdk_root, version, **push_kwargs)
             else:
@@ -254,7 +254,7 @@ def enable_cmd(pdk_root, tool_metadata_file_path, version):
     """
     console = rich.console.Console()
     version = check_version(version, tool_metadata_file_path, console)
-    enable(pdk_root, version)
+    enable(pdk_root=pdk_root, pdk="sky130", version=version)
 
 
 @click.command("enable_or_build", hidden=True)
@@ -292,8 +292,9 @@ def enable_or_build_cmd(
     console = rich.console.Console()
     version = check_version(version, tool_metadata_file_path, console)
     enable(
-        pdk_root,
-        version,
+        pdk_root=pdk_root,
+        pdk="sky130",
+        version=version,
         build_if_not_found=True,
         also_push=also_push,
         build_kwargs={


### PR DESCRIPTION
+ Exposes two APIs, `build` and `enable` that can be used from inside Python.
+ Type annotations have been added for these two functions and a new, currently unused parameter has been added to maybe support ASAP7 in the future.
~ Build system has been migrated from the `build` package to something more... common.