### PR TITLE
Use TemporaryDirectory

### DIFF
--- a/volare/__init__.py
+++ b/volare/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 from .manage import enable
 from .build import build

--- a/volare/manage.py
+++ b/volare/manage.py
@@ -15,7 +15,6 @@
 import os
 import sys
 import json
-import uuid
 import tarfile
 import pathlib
 import requests


### PR DESCRIPTION
This resolves an issue where the first user on a multi-user setup to install volare will own the /tmp/volare folder indefinitely and disable Volare for other users.