### PR TITLE
Multi-PDK Support + Build System Overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+!volare/build
 pdk/
 __pycache__
 venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml~=5.4.0
 rich~=10.16.0
 requests~=2.27.0
 click-default-group~=1.2.2
+pcpp~=1.30

--- a/volare/__init__.py
+++ b/volare/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.1.4"
+__version__ = "0.2.0"
 
 from .manage import enable
 from .build import build

--- a/volare/build/__init__.py
+++ b/volare/build/__init__.py
@@ -1,0 +1,160 @@
+import os
+import uuid
+import pathlib
+import tarfile
+import tempfile
+import subprocess
+from typing import Optional, List
+
+import rich
+import click
+from rich.progress import Progress
+
+from ..common import (
+    mkdirp,
+    opt_push,
+    opt_build,
+    opt_pdk_root,
+    check_version,
+    get_version_dir,
+    VOLARE_REPO_NAME,
+    VOLARE_REPO_OWNER,
+)
+from .sky130 import build_sky130
+from .asap7 import build_asap7
+
+
+def build(
+    pdk_root: str,
+    pdk: str,
+    version: str,
+    jobs: int = 1,
+    sram: bool = True,
+    clear_build_artifacts: bool = True,
+    include_libraries: Optional[List[str]] = None,
+):
+    if pdk == "sky130":
+        build_sky130(
+            pdk_root, version, jobs, sram, clear_build_artifacts, include_libraries
+        )
+    elif pdk == "asap7":
+        build_asap7(
+            pdk_root, version, jobs, sram, clear_build_artifacts, include_libraries
+        )
+    else:
+        raise Exception(f"Unsupported pdk family {pdk}")
+
+
+@click.command("build")
+@opt_pdk_root
+@opt_build
+@click.option(
+    "-f",
+    "--metadata-file",
+    "tool_metadata_file_path",
+    default=None,
+    help="Explicitly define a tool metadata file instead of searching for a metadata file",
+)
+@click.argument("version", required=False)
+def build_cmd(
+    include_libraries,
+    jobs,
+    sram,
+    pdk_root,
+    pdk,
+    clear_build_artifacts,
+    tool_metadata_file_path,
+    version,
+):
+    """
+    Builds the requested PDK.
+
+    Parameters: <version> (Optional)
+
+    If a version is not given, and you run this in the top level directory of
+    tools with a tool_metadata.yml file, for example OpenLane or DFFRAM,
+    the appropriate version will be enabled automatically.
+    """
+
+    version = check_version(version, tool_metadata_file_path, rich.console.Console())
+    build(
+        pdk_root=pdk_root,
+        pdk=pdk,
+        version=version,
+        jobs=jobs,
+        sram=sram,
+        clear_build_artifacts=clear_build_artifacts,
+        include_libraries=include_libraries,
+    )
+
+
+def push(
+    pdk_root,
+    pdk,
+    version,
+    owner=VOLARE_REPO_OWNER,
+    repository=VOLARE_REPO_NAME,
+    token=os.getenv("GITHUB_TOKEN"),
+):
+    console = rich.console.Console()
+
+    version_directory = get_version_dir(pdk_root, pdk, version)
+    if not os.path.isdir(version_directory):
+        console.print("[red]Version not found.")
+        exit(os.EX_NOINPUT)
+
+    tempdir = tempfile.gettempdir()
+    tarball_directory = os.path.join(tempdir, "volare", f"{uuid.uuid4()}", version)
+    mkdirp(tarball_directory)
+
+    tarball_path = os.path.join(tarball_directory, "default.tar.xz")
+
+    with Progress() as progress:
+        path_it = pathlib.Path(version_directory).glob("**/*")
+        files = [str(path) for path in path_it if path.is_file()]
+        task = progress.add_task("Compressing…", total=len(files))
+        with tarfile.open(tarball_path, mode="w:xz") as tf:
+            for i, file in enumerate(files):
+                progress.update(task, completed=i + 1)
+                path_in_tarball = os.path.relpath(file, version_directory)
+                tf.add(file, arcname=path_in_tarball)
+    console.log(f"Compressed to {tarball_path}.")
+
+    tag = f"{pdk}-{version}"
+
+    # If someone wants to rewrite this to not use ghr, please, by all means.
+    console.log("Starting upload…")
+    subprocess.check_call(
+        [
+            "ghr",
+            "-owner",
+            owner,
+            "-repository",
+            repository,
+            "-token",
+            token,
+            "-body",
+            f"Volare build of {pdk} variants (v{version})",
+            "-commitish",
+            "releases",
+            "-replace",
+            tag,
+            tarball_path,
+        ]
+    )
+    console.log("Done.")
+
+
+@click.command("push", hidden=True)
+@opt_pdk_root
+@opt_push
+@click.argument("version")
+def push_cmd(owner, repository, token, pdk_root, pdk, version):
+    """
+    For maintainers: Package and release a build to the public.
+
+    Requires ghr: github.com/tcnksm/ghr
+
+    Parameters: <version> (required)
+    """
+    push(pdk_root, pdk, version, owner, repository, token)

--- a/volare/build/asap7.py
+++ b/volare/build/asap7.py
@@ -1,6 +1,4 @@
 import os
-import venv
-import uuid
 import shutil
 import subprocess
 from typing import Optional, List
@@ -9,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 import rich
 from rich.progress import Progress
 
-from .git_multi_clone import GitMultiClone, Repository
+from .git_multi_clone import GitMultiClone
 from ..common import (
     RepoMetadata,
     get_version_dir,

--- a/volare/build/asap7.py
+++ b/volare/build/asap7.py
@@ -1,0 +1,138 @@
+import os
+import venv
+import uuid
+import shutil
+import subprocess
+from typing import Optional, List
+from concurrent.futures import ThreadPoolExecutor
+
+import rich
+from rich.progress import Progress
+
+from .git_multi_clone import GitMultiClone, Repository
+from ..common import (
+    RepoMetadata,
+    get_version_dir,
+    get_volare_dir,
+    get_variants,
+    mkdirp,
+)
+
+repo_metadata = {
+    "orfs": RepoMetadata(
+        "https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts",
+        "b541139f4da34687340bf2e55528707e76fce233",
+        "master",
+    )
+}
+
+
+def get_orfs(version, build_directory, jobs=1):
+    try:
+        console = rich.console.Console()
+
+        orfs_repo = None
+
+        with Progress() as progress:
+            with ThreadPoolExecutor(max_workers=jobs) as executor:
+                gmc = GitMultiClone(build_directory, progress)
+                orfs = repo_metadata["orfs"]
+                orfs_future = executor.submit(
+                    GitMultiClone.clone,
+                    gmc,
+                    orfs.repo,
+                    version,
+                    orfs.default_branch,
+                )
+                orfs_repo = orfs_future.result()
+
+        console.log(f"Done fetching {orfs_repo.name}.")
+
+    except subprocess.CalledProcessError as e:
+        print(e)
+        print(e.stderr)
+        exit(os.EX_DATAERR)
+
+
+def build_variants(build_directory, jobs):
+    PDK_LINKER_SCRIPT = "https://raw.githubusercontent.com/The-OpenROAD-Project/OpenLane/01e951092150ee8619286b0807ee263198b5ea6d/scripts/pdk-linker.py"
+
+    subprocess.check_call(
+        [
+            "sed",
+            "-i",
+            "s/grid_strategy-M2-M5-M7.cfg/grid_strategy-M2-M5-M7.tcl/",
+            "./OpenROAD-flow-scripts/flow/platforms/asap7/openlane/mapping.json",
+        ],
+        cwd=build_directory,
+    )
+    subprocess.check_call(
+        [
+            "sed",
+            "-i",
+            "s/grid_strategy-M2-M5-M7.cfg/grid_strategy-M2-M5-M7.tcl/",
+            "./OpenROAD-flow-scripts/flow/platforms/asap7/openlane/asap7sc7p5t/config.tcl",
+        ],
+        cwd=build_directory,
+    )
+
+    subprocess.check_call(["curl", "-LO", PDK_LINKER_SCRIPT], cwd=build_directory)
+
+    subprocess.check_call(
+        [
+            "python3",
+            "./pdk-linker.py",
+            "-s",
+            "OpenROAD-flow-scripts",
+            "-d",
+            "asap7",
+            "-m",
+            "./OpenROAD-flow-scripts/flow/platforms/asap7/openlane/mapping.json",
+        ],
+        cwd=build_directory,
+    )
+
+
+def install_asap7(build_directory, pdk_root, version):
+    console = rich.console.Console()
+    with console.status("Adding build to list of installed versions…"):
+        version_directory = get_version_dir(pdk_root, "asap7", version)
+        print(version_directory)
+        if (
+            os.path.exists(version_directory)
+            and len(os.listdir(version_directory)) != 0
+        ):
+            backup_path = version_directory
+            it = 0
+            while os.path.exists(backup_path) and len(os.listdir(backup_path)) != 0:
+                it += 1
+                backup_path = get_version_dir(pdk_root, "asap7", f"{version}.bk{it}")
+            console.log(
+                f"Build already found at {version_directory}, moving to {backup_path}…"
+            )
+            shutil.move(version_directory, backup_path)
+
+        console.log("Copying…")
+        mkdirp(version_directory)
+
+        for variant in get_variants("asap7"):
+            variant_build_path = os.path.join(build_directory, variant)
+            variant_install_path = os.path.join(version_directory, variant)
+            shutil.copytree(variant_build_path, variant_install_path)
+
+    console.log("Done.")
+
+
+def build_asap7(
+    pdk_root: str,
+    version: str,
+    jobs: int = 1,
+    sram: bool = True,
+    clear_build_artifacts: bool = True,
+    include_libraries: Optional[List[str]] = None,
+):
+    build_directory = os.path.join(get_volare_dir(pdk_root, "asap7"), "build", version)
+
+    get_orfs(version, build_directory, jobs)
+    build_variants(build_directory, jobs)
+    install_asap7(build_directory, pdk_root, version)

--- a/volare/build/git_multi_clone.py
+++ b/volare/build/git_multi_clone.py
@@ -15,14 +15,11 @@
 import os
 import re
 import shutil
-import pathlib
 import subprocess
 
 from rich.progress import Progress
 
-
-def mkdirp(path):
-    return pathlib.Path(path).mkdir(parents=True, exist_ok=True)
+from ..common import mkdirp
 
 
 class Repository(object):

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -26,7 +26,7 @@ repo_metadata = {
     ),
     "magic": RepoMetadata(
         "https://github.com/RTimothyEdwards/magic",
-        "d98645afc1498a41db7aff4b2e100f27e0b0bd9b",
+        "085131b090cb511d785baf52a10cf6df8a657d44",
         "master",
     ),
 }
@@ -252,25 +252,13 @@ def build_variants(sram, build_directory, jobs=1):
             )
             console.log("Done.")
 
-            console.log("Building prequisites…")
+            console.log("Building PDK Variants…")
             docker_run(
                 "sh",
                 "-c",
                 f"""
                     set +e
-                    cd open_pdks/sky130
-                    make -j{jobs} prerequisites
-                """,
-            )
-            console.log("Done.")
-
-            console.log("Building sky130A/B…")
-            docker_run(
-                "sh",
-                "-c",
-                f"""
-                    set +e
-                    cd open_pdks/sky130
+                    cd open_pdks
                     export LC_ALL=en_US.UTF-8
                     make -j{jobs}
                     make SHARED_PDKS_PATH=$PDK_ROOT install

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -83,15 +83,15 @@ def get_open_pdks(
             magic_tag = reference_commits["magic"]
         except FileNotFoundError:
             console.log(
-                f"Cannot find open_pdks/sky130 JSON manifest. Default versions for sky130/magic will be used."
+                "Cannot find open_pdks/sky130 JSON manifest. Default versions for sky130/magic will be used."
             )
         except json.JSONDecodeError:
             console.log(
-                f"Failed to parse open_pdks/sky130 JSON manifest. Default versions for sky130/magic will be used."
+                "Failed to parse open_pdks/sky130 JSON manifest. Default versions for sky130/magic will be used."
             )
         except KeyError:
             console.log(
-                f"Failed to extract reference commits from open_pdks/sky130 JSON manifest. Default versions for sky130/magic will be used."
+                "Failed to extract reference commits from open_pdks/sky130 JSON manifest. Default versions for sky130/magic will be used."
             )
 
         return (sky130_tag, magic_tag)

--- a/volare/common.py
+++ b/volare/common.py
@@ -199,7 +199,5 @@ def get_version_list(pdk: str) -> List[str]:
 
 
 def get_logs_dir() -> str:
-    logs_dir = os.getenv("VOLARE_LOGS") or os.path.join(
-        VOLARE_DEFAULT_HOME, "logs"
-    )
+    logs_dir = os.getenv("VOLARE_LOGS") or os.path.join(VOLARE_DEFAULT_HOME, "logs")
     return logs_dir

--- a/volare/common.py
+++ b/volare/common.py
@@ -35,6 +35,7 @@ VOLARE_REPO_NAME = os.getenv("VOLARE_REPO_NAME") or "volare"
 VOLARE_REPO_ID = f"{VOLARE_REPO_OWNER}/{VOLARE_REPO_NAME}"
 VOLARE_REPO_HTTPS = f"https://github.com/{VOLARE_REPO_ID}"
 VOLARE_REPO_API = f"https://api.github.com/repos/{VOLARE_REPO_ID}"
+VOLARE_DEFAULT_HOME = os.path.join(os.path.expanduser("~"), ".volare")
 
 opt = partial(click.option, show_default=True)
 
@@ -54,7 +55,7 @@ def opt_pdk_root(function: Callable):
     function = click.option(
         "--pdk-root",
         required=False,
-        default=os.getenv("PDK_ROOT") or os.path.expanduser("~/.volare"),
+        default=os.getenv("PDK_ROOT") or VOLARE_DEFAULT_HOME,
         help="Path to the PDK root",
         show_default=True,
     )(function)
@@ -195,3 +196,10 @@ def get_version_list(pdk: str) -> List[str]:
             pdk_versions_by_pdk[family] = pdk_versions_by_pdk.get(family) or []
         pdk_versions_by_pdk[family].append(hash)
     return pdk_versions_by_pdk.get(pdk) or []
+
+
+def get_logs_dir() -> str:
+    logs_dir = os.getenv("VOLARE_LOGS") or os.path.join(
+        VOLARE_DEFAULT_HOME, "logs"
+    )
+    return logs_dir

--- a/volare/common.py
+++ b/volare/common.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import os
 import json
+import pathlib
 import requests
 from functools import partial
 from typing import Optional, Callable, List
@@ -21,24 +22,35 @@ from typing import Optional, Callable, List
 import rich
 import click
 
+
+class RepoMetadata(object):
+    def __init__(self, repo, default_commit, default_branch="main"):
+        self.repo = repo
+        self.default_commit = default_commit
+        self.default_branch = default_branch
+
+
 VOLARE_REPO_OWNER = os.getenv("VOLARE_REPO_OWNER") or "efabless"
 VOLARE_REPO_NAME = os.getenv("VOLARE_REPO_NAME") or "volare"
 VOLARE_REPO_ID = f"{VOLARE_REPO_OWNER}/{VOLARE_REPO_NAME}"
 VOLARE_REPO_HTTPS = f"https://github.com/{VOLARE_REPO_ID}"
 VOLARE_REPO_API = f"https://api.github.com/repos/{VOLARE_REPO_ID}"
 
-SKY130_VARIANTS = ["sky130A", "sky130B"]
-SKY130_DEFAULT_LIBRARIES = [
-    "sky130_fd_sc_hd",
-    "sky130_fd_sc_hvl",
-    "sky130_fd_io",
-    "sky130_fd_pr",
-]
-
 opt = partial(click.option, show_default=True)
 
 
+def mkdirp(path):
+    return pathlib.Path(path).mkdir(parents=True, exist_ok=True)
+
+
 def opt_pdk_root(function: Callable):
+    function = click.option(
+        "--pdk",
+        required=False,
+        default=os.getenv("PDK") or "sky130",
+        help="The PDK family to install",
+        show_default=True,
+    )(function)
     function = click.option(
         "--pdk-root",
         required=False,
@@ -54,8 +66,8 @@ def opt_build(function: Callable):
         "-l",
         "--include-libraries",
         multiple=True,
-        default=SKY130_DEFAULT_LIBRARIES,
-        help="Libraries to include in the build. You can use -l multiple times to include multiple libraries. Pass 'all' to include all of them.",
+        default=None,
+        help="Libraries to include in the build. You can use -l multiple times to include multiple libraries. Pass 'all' to include all of them. A default of 'None' uses a default set for the particular PDK.",
     )(function)
     function = opt(
         "-j",
@@ -84,7 +96,6 @@ def opt_push(function: Callable):
     function = opt(
         "-t",
         "--token",
-        required=(os.getenv("GITHUB_TOKEN") is None),
         default=os.getenv("GITHUB_TOKEN"),
         help="Github Token",
     )(function)
@@ -149,30 +160,38 @@ def check_version(
     return version
 
 
-def get_volare_dir(pdk_root: str) -> str:
-    return os.path.join(pdk_root, "volare", "sky130")
+def get_variants(pdk: str) -> List[str]:
+    if pdk == "sky130":
+        return ["sky130A", "sky130B"]
+    if pdk == "asap7":
+        return ["asap7"]
+    return []
 
 
-def get_versions_dir(pdk_root: str) -> str:
-    return os.path.join(get_volare_dir(pdk_root), "versions")
+def get_volare_dir(pdk_root: str, pdk: str) -> str:
+    return os.path.join(pdk_root, "volare", pdk)
 
 
-def get_version_dir(pdk_root: str, version: str) -> str:
-    return os.path.join(get_versions_dir(pdk_root), version)
+def get_versions_dir(pdk_root: str, pdk: str) -> str:
+    return os.path.join(get_volare_dir(pdk_root, pdk), "versions")
 
 
-def get_link_of(version: str) -> str:
-    return f"{VOLARE_REPO_HTTPS}/releases/download/sky130-{version}/default.tar.xz"
+def get_version_dir(pdk_root: str, pdk: str, version: str) -> str:
+    return os.path.join(get_versions_dir(pdk_root, pdk), version)
 
 
-def get_version_list() -> List[str]:
+def get_link_of(version: str, pdk: str) -> str:
+    return f"{VOLARE_REPO_HTTPS}/releases/download/{pdk}-{version}/default.tar.xz"
+
+
+def get_version_list(pdk: str) -> List[str]:
     response_str = requests.get(f"{VOLARE_REPO_API}/releases").content.decode("utf8")
     releases = json.loads(response_str)
     pdk_versions = [release["tag_name"] for release in releases]
     pdk_versions_by_pdk = {}
     for version in pdk_versions:
-        pdk, hash = version.split("-")
-        if pdk_versions_by_pdk.get(pdk) is None:
-            pdk_versions_by_pdk[pdk] = pdk_versions_by_pdk.get(pdk) or []
-        pdk_versions_by_pdk[pdk].append(hash)
-    return pdk_versions_by_pdk["sky130"]
+        family, hash = version.split("-")
+        if pdk_versions_by_pdk.get(family) is None:
+            pdk_versions_by_pdk[family] = pdk_versions_by_pdk.get(family) or []
+        pdk_versions_by_pdk[family].append(hash)
+    return pdk_versions_by_pdk.get(pdk) or []

--- a/volare/manage.py
+++ b/volare/manage.py
@@ -37,7 +37,6 @@ from .common import (
     get_versions_dir,
     get_version_dir,
     get_volare_dir,
-    get_variants,
     get_version_list,
 )
 from .build import build, push

--- a/volare/manage.py
+++ b/volare/manage.py
@@ -25,9 +25,10 @@ import rich.tree
 import click
 import rich.progress
 
-from .git_multi_clone import mkdirp
+from .build.git_multi_clone import mkdirp
 from .common import (
     get_link_of,
+    get_variants,
     opt,
     opt_build,
     opt_push,
@@ -36,26 +37,26 @@ from .common import (
     get_versions_dir,
     get_version_dir,
     get_volare_dir,
-    SKY130_VARIANTS,
+    get_variants,
     get_version_list,
 )
 from .build import build, push
 
 
-def get_installed_list(pdk_root):
-    versions_dir = get_versions_dir(pdk_root)
+def get_installed_list(pdk_root, pdk):
+    versions_dir = get_versions_dir(pdk_root, pdk)
     mkdirp(versions_dir)
     return os.listdir(versions_dir)
 
 
-def print_installed_list(pdk_root, console):
-    installed_list = get_installed_list(pdk_root)
-    versions_dir = get_versions_dir(pdk_root)
+def print_installed_list(pdk_root, pdk, console):
+    installed_list = get_installed_list(pdk_root, pdk)
+    versions_dir = get_versions_dir(pdk_root, pdk)
     if len(installed_list) == 0:
         console.print("[red]No PDKs installed.")
         return
 
-    version = get_current_version(pdk_root)
+    version = get_current_version(pdk_root, pdk)
 
     tree = rich.tree.Tree(f"{versions_dir}")
     for installed in installed_list:
@@ -66,10 +67,10 @@ def print_installed_list(pdk_root, console):
     console.print(tree)
 
 
-def print_remote_list(pdk_root, console, pdk_list):
-    installed_list = get_installed_list(pdk_root)
+def print_remote_list(pdk_root, pdk, console, pdk_list):
+    installed_list = get_installed_list(pdk_root, pdk)
 
-    version = get_current_version(pdk_root)
+    version = get_current_version(pdk_root, pdk)
 
     tree = rich.tree.Tree("Pre-built PDKs")
     for pdk in pdk_list:
@@ -82,8 +83,8 @@ def print_remote_list(pdk_root, console, pdk_list):
     console.print(tree)
 
 
-def get_current_version(pdk_root):
-    current_file = os.path.join(get_volare_dir(pdk_root), "current")
+def get_current_version(pdk_root, pdk):
+    current_file = os.path.join(get_volare_dir(pdk_root, pdk), "current")
     current_file_dir = os.path.dirname(current_file)
     mkdirp(current_file_dir)
     pathlib.Path(current_file).touch(exist_ok=True)
@@ -93,14 +94,14 @@ def get_current_version(pdk_root):
 
 @click.command("output")
 @opt_pdk_root
-def output_cmd(pdk_root):
+def output_cmd(pdk_root, pdk):
     """(Default) Outputs the currently installed PDK version."""
 
     if sys.stdout.isatty():
         console = rich.console.Console()
-        print_installed_list(pdk_root, console)
+        print_installed_list(pdk_root, pdk, console)
     else:
-        version = get_current_version()
+        version = get_current_version(pdk)
         if version == "":
             exit(1)
         else:
@@ -109,14 +110,14 @@ def output_cmd(pdk_root):
 
 @click.command("list", hidden=True)
 @opt_pdk_root
-def list_cmd(pdk_root):
+def list_cmd(pdk_root, pdk):
     """Lists PDK versions that are remotely available. JSON if not outputting to a tty."""
 
-    pdk_versions = get_version_list()
+    pdk_versions = get_version_list(pdk)
 
     if sys.stdout.isatty():
         console = rich.console.Console()
-        print_remote_list(pdk_root, console, pdk_versions)
+        print_remote_list(pdk_root, pdk, console, pdk_versions)
     else:
         print(json.dumps(pdk_versions))
 
@@ -124,11 +125,11 @@ def list_cmd(pdk_root):
 @click.command("path")
 @opt_pdk_root
 @click.argument("version", required=False)
-def path_cmd(pdk_root, version):
+def path_cmd(pdk_root, pdk, version):
     """Prints the path of a specific pdk version installation."""
     path_to_print = pdk_root
     if version is not None:
-        path_to_print = os.path.join(get_versions_dir(pdk_root), version)
+        path_to_print = os.path.join(get_versions_dir(pdk_root, pdk), version)
     print(path_to_print, end="")
 
 
@@ -143,19 +144,19 @@ def enable(
 ):
     console = rich.console.Console()
 
-    current_file = os.path.join(get_volare_dir(pdk_root), "current")
+    current_file = os.path.join(get_volare_dir(pdk_root, pdk), "current")
     current_file_dir = os.path.dirname(current_file)
     mkdirp(current_file_dir)
 
-    version_directory = get_version_dir(pdk_root, version)
+    version_directory = get_version_dir(pdk_root, pdk, version)
 
-    version_paths = [
-        os.path.join(version_directory, variant) for variant in SKY130_VARIANTS
-    ]
-    final_paths = [os.path.join(pdk_root, variant) for variant in SKY130_VARIANTS]
+    variants = get_variants(pdk)
+
+    version_paths = [os.path.join(version_directory, variant) for variant in variants]
+    final_paths = [os.path.join(pdk_root, variant) for variant in variants]
 
     if not os.path.exists(version_directory):
-        link = get_link_of(version)
+        link = get_link_of(version, pdk)
         status = requests.head(link).status_code
         if status == 404:
             console.print(f"Version {version} not found either locally or remotely.")
@@ -196,7 +197,7 @@ def enable(
                                     with open(final_path, "wb") as f:
                                         f.write(io.read())
 
-                        for variant in SKY130_VARIANTS:
+                        for variant in variants:
                             variant_install_path = os.path.join(
                                 version_directory, variant
                             )
@@ -240,7 +241,7 @@ def enable(
     help="Explicitly define a tool metadata file instead of searching for a metadata file",
 )
 @click.argument("version", required=False)
-def enable_cmd(pdk_root, tool_metadata_file_path, version):
+def enable_cmd(pdk_root, pdk, tool_metadata_file_path, version):
     """
     Activates a given PDK version.
 
@@ -252,7 +253,7 @@ def enable_cmd(pdk_root, tool_metadata_file_path, version):
     """
     console = rich.console.Console()
     version = check_version(version, tool_metadata_file_path, console)
-    enable(pdk_root=pdk_root, pdk="sky130", version=version)
+    enable(pdk_root=pdk_root, pdk=pdk, version=version)
 
 
 @click.command("enable_or_build", hidden=True)
@@ -273,6 +274,7 @@ def enable_or_build_cmd(
     jobs,
     sram,
     pdk_root,
+    pdk,
     owner,
     repository,
     token,
@@ -291,7 +293,7 @@ def enable_or_build_cmd(
     version = check_version(version, tool_metadata_file_path, console)
     enable(
         pdk_root=pdk_root,
-        pdk="sky130",
+        pdk=pdk,
         version=version,
         build_if_not_found=True,
         also_push=also_push,


### PR DESCRIPTION
+ Extract reference versions of `open_pdks`, `magic` from compatible versions of open_pdks
+ `--pdk` flag added for almost all CLI functions (default: `sky130`)
+ Add build for ASAP7 PDK (although it's not working with OpenLane atm)
~ `volare.build` now a dedicated module
~ build logs moved to `~/.volare`, overridable by environment variable `VOLARE_LOGS`