### PR TITLE
Fix issue where Volare was sensitive to the wrong variable

### DIFF
--- a/volare/__init__.py
+++ b/volare/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 from .manage import enable
 from .build import build

--- a/volare/common.py
+++ b/volare/common.py
@@ -48,7 +48,7 @@ def opt_pdk_root(function: Callable):
     function = click.option(
         "--pdk",
         required=False,
-        default=os.getenv("PDK") or "sky130",
+        default=os.getenv("PDK_FAMILY") or "sky130",
         help="The PDK family to install",
         show_default=True,
     )(function)

--- a/volare/manage.py
+++ b/volare/manage.py
@@ -71,7 +71,7 @@ def print_remote_list(pdk_root, pdk, console, pdk_list):
 
     version = get_current_version(pdk_root, pdk)
 
-    tree = rich.tree.Tree("Pre-built PDKs")
+    tree = rich.tree.Tree(f"Pre-built {pdk} PDK versions")
     for pdk in pdk_list:
         if pdk == version:
             tree.add(f"[green][bold]{pdk} (enabled)")


### PR DESCRIPTION
Volare would use the variable OpenLane uses for PDK variants, `PDK`, for the PDK family proper. It's been changed to `PDK_FAMILY`.