### PR TITLE
Add ability to build using local repositories for testing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,7 @@ Volare requires a so-called **PDK Root**. This PDK root can be anywhere on your 
 Simply typing `volare` in the terminal shows you your PDK Root and the PDKs you currently have installed.
 
 ```sh
-$ volare
+$ volare ls
 /home/test/.volare
 ├── 5890e791e37699239abedfd2a67e55162e25cd94 (enabled)
 ├── 660c6bdc8715dc7b3db95a1ce85392bbf2a2b195
@@ -42,10 +42,10 @@ $ volare
 ```
 
 ## Listing All Available PDKs
-To list all available pre-built PDKs, you can just invoke `volare list`.
+To list all available pre-built PDKs, you can just invoke `volare ls-remote`.
 
 ```sh
-$ volare list
+$ volare ls-remote
 Pre-built PDKs
 ├── 8fe7f760ece2bb49b1c310e60243f0558977dae5 (installed)
 ├── 7519dfb04400f224f140749cda44ee7de6f5e095

--- a/volare/__init__.py
+++ b/volare/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 from .manage import enable
 from .build import build

--- a/volare/__main__.py
+++ b/volare/__main__.py
@@ -17,7 +17,14 @@ from click_default_group import DefaultGroup
 
 from . import __version__
 from .build import build_cmd, push_cmd
-from .manage import output_cmd, path_cmd, list_cmd, enable_cmd, enable_or_build_cmd
+from .manage import (
+    output_cmd,
+    path_cmd,
+    list_cmd,
+    list_remote_cmd,
+    enable_cmd,
+    enable_or_build_cmd,
+)
 
 
 @click.group(
@@ -35,6 +42,7 @@ cli.add_command(build_cmd)
 cli.add_command(push_cmd)
 cli.add_command(path_cmd)
 cli.add_command(list_cmd)
+cli.add_command(list_remote_cmd)
 cli.add_command(enable_cmd)
 cli.add_command(enable_or_build_cmd)
 

--- a/volare/build/__init__.py
+++ b/volare/build/__init__.py
@@ -32,14 +32,33 @@ def build(
     sram: bool = True,
     clear_build_artifacts: bool = True,
     include_libraries: Optional[List[str]] = None,
+    use_repo_at: Optional[List[str]] = None,
 ):
+    use_repos = {}
+    if use_repo_at is not None:
+        for repo in use_repo_at:
+            name, path = repo.split("=")
+            use_repos[name] = os.path.abspath(path)
+
     if pdk == "sky130":
         build_sky130(
-            pdk_root, version, jobs, sram, clear_build_artifacts, include_libraries
+            pdk_root,
+            version,
+            jobs,
+            sram,
+            clear_build_artifacts,
+            include_libraries,
+            use_repos,
         )
     elif pdk == "asap7":
         build_asap7(
-            pdk_root, version, jobs, sram, clear_build_artifacts, include_libraries
+            pdk_root,
+            version,
+            jobs,
+            sram,
+            clear_build_artifacts,
+            include_libraries,
+            use_repos,
         )
     else:
         raise Exception(f"Unsupported pdk family {pdk}")
@@ -65,6 +84,7 @@ def build_cmd(
     clear_build_artifacts,
     tool_metadata_file_path,
     version,
+    use_repo_at,
 ):
     """
     Builds the requested PDK.
@@ -85,6 +105,7 @@ def build_cmd(
         sram=sram,
         clear_build_artifacts=clear_build_artifacts,
         include_libraries=include_libraries,
+        use_repo_at=use_repo_at,
     )
 
 

--- a/volare/build/asap7.py
+++ b/volare/build/asap7.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import subprocess
-from typing import Optional, List
+from typing import Optional, List, Dict
 from concurrent.futures import ThreadPoolExecutor
 
 import rich
@@ -128,7 +128,9 @@ def build_asap7(
     sram: bool = True,
     clear_build_artifacts: bool = True,
     include_libraries: Optional[List[str]] = None,
+    using_repos: Dict[str, str] = None,
 ):
+    # TODO: Support using_repos
     build_directory = os.path.join(get_volare_dir(pdk_root, "asap7"), "build", version)
 
     get_orfs(version, build_directory, jobs)

--- a/volare/common.py
+++ b/volare/common.py
@@ -84,6 +84,15 @@ def opt_build(function: Callable):
         default=False,
         help="Whether or not to remove the build artifacts. Keeping the build artifacts is useful when testing.",
     )(function)
+    function = opt(
+        "-r",
+        "--use-repo-at",
+        default=None,
+        multiple=True,
+        hidden=True,
+        type=str,
+        help="Use this repository instead of cloning and checking out, in the format repo_name=/path/to/repo. You can pass it multiple times to replace multiple repos. This feature is intended for volare and PDK developers.",
+    )(function)
     return function
 
 
@@ -199,5 +208,9 @@ def get_version_list(pdk: str) -> List[str]:
 
 
 def get_logs_dir() -> str:
-    logs_dir = os.getenv("VOLARE_LOGS") or os.path.join(VOLARE_DEFAULT_HOME, "logs")
-    return logs_dir
+    if os.getenv("VOLARE_LOGS") is not None:
+        return os.environ["VOLARE_LOGS"]
+    elif os.getenv("PDK_ROOT") is not None:
+        return os.path.join(os.environ["PDK_ROOT"], "volare", "logs")
+    else:
+        return os.path.join(VOLARE_DEFAULT_HOME, "volare", "logs")

--- a/volare/manage.py
+++ b/volare/manage.py
@@ -281,6 +281,7 @@ def enable_or_build_cmd(
     tool_metadata_file_path,
     also_push,
     version,
+    use_repo_at,
 ):
     """
     Attempts to activate a given PDK version. If the version is not found locally or remotely,
@@ -301,6 +302,7 @@ def enable_or_build_cmd(
             "jobs": jobs,
             "sram": sram,
             "clear_build_artifacts": clear_build_artifacts,
+            "use_repo_at": use_repo_at,
         },
         push_kwargs={"owner": owner, "repository": repository, "token": token},
     )

--- a/volare/manage.py
+++ b/volare/manage.py
@@ -106,13 +106,13 @@ def output_cmd(pdk_root, pdk):
         if version == "":
             print(f"No version of the PDK {pdk} is currently enabled at {pdk_root}.")
             print(
-                f"Invoke volare --help for assistance installing and enabling versions."
+                "Invoke volare --help for assistance installing and enabling versions."
             )
             exit(1)
         else:
             print(f"Installed: {pdk} v{version}")
             print(
-                f"Invoke volare --help for assistance installing and enabling versions."
+                "Invoke volare --help for assistance installing and enabling versions."
             )
     else:
         if version == "":

--- a/volare/manage.py
+++ b/volare/manage.py
@@ -94,22 +94,47 @@ def get_current_version(pdk_root, pdk):
 @click.command("output")
 @opt_pdk_root
 def output_cmd(pdk_root, pdk):
-    """(Default) Outputs the currently installed PDK version."""
+    """(Default) Outputs the currently enabled PDK version.
 
+    If not outputting to a tty, the output is either the version string
+    unembellished, or, if no current version is enabled, an empty output with an
+    exit code of 1.
+    """
+
+    version = get_current_version(pdk_root, pdk)
     if sys.stdout.isatty():
-        console = rich.console.Console()
-        print_installed_list(pdk_root, pdk, console)
+        if version == "":
+            print(f"No version of the PDK {pdk} is currently enabled at {pdk_root}.")
+            print(
+                f"Invoke volare --help for assistance installing and enabling versions."
+            )
+            exit(1)
+        else:
+            print(f"Installed: {pdk} v{version}")
+            print(
+                f"Invoke volare --help for assistance installing and enabling versions."
+            )
     else:
-        version = get_current_version(pdk)
         if version == "":
             exit(1)
         else:
             print(version, end="")
 
 
-@click.command("list", hidden=True)
+@click.command("ls")
 @opt_pdk_root
 def list_cmd(pdk_root, pdk):
+    """Lists PDK versions that are locally installed. JSON if not outputting to a tty."""
+    if sys.stdout.isatty():
+        console = rich.console.Console()
+        print_installed_list(pdk_root, pdk, console)
+    else:
+        print(json.dumps(get_installed_list(pdk_root, pdk)), end="")
+
+
+@click.command("ls-remote")
+@opt_pdk_root
+def list_remote_cmd(pdk_root, pdk):
     """Lists PDK versions that are remotely available. JSON if not outputting to a tty."""
 
     pdk_versions = get_version_list(pdk)
@@ -118,7 +143,7 @@ def list_cmd(pdk_root, pdk):
         console = rich.console.Console()
         print_remote_list(pdk_root, pdk, console, pdk_versions)
     else:
-        print(json.dumps(pdk_versions))
+        print(json.dumps(pdk_versions), end="")
 
 
 @click.command("path")
@@ -242,7 +267,7 @@ def enable(
 @click.argument("version", required=False)
 def enable_cmd(pdk_root, pdk, tool_metadata_file_path, version):
     """
-    Activates a given PDK version.
+    Activates a given installed PDK version.
 
     Parameters: <version> (Optional)
 


### PR DESCRIPTION
+ Adds new (hidden) commandline parameter, `use_repo_at`, that allows versions of `open_pdks` and `skywater-pdk` that are cloned automatically to be pointed to a local repository (not compatible with ASAP7)
+ Added `volare ls` listing locally installed PDKs
~ `volare list` -> `volare ls-remote`
~ `volare output` (the default) subcommand now no longer lists anything, just shows the version