### PR TITLE
github/workflows: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  pdk:
+    strategy:
+      matrix:
+        family: ['sky130', 'gf180mcu']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: install volare
+        run: |
+          python -m venv env
+          env/bin/python -m pip install -r requirements.txt
+          env/bin/python -m pip install .
+
+      - uses: actions/checkout@v3
+        with:
+          repository: 'The-OpenROAD-Project/OpenLane'
+          path: 'OpenLane'
+
+      - name: build
+        run: |
+          env/bin/volare build \
+            --pdk ${{ matrix.family }} \
+            --metadata-file=OpenLane/dependencies/tool_metadata.yml
+
+      - name: compress
+        run: |
+          VOLARE_PATH=$(env/bin/volare path)
+          PDK_FAMILY=${{ matrix.family }}
+          PDK_VERSION=$(cat $VOLARE_PATH/$PDK_FAMILY/current)
+          tar -C $VOLARE_PATH/$PDK_FAMILY/versions/$PDK_VERSION \
+              -cvJf default.tar.xz .
+          echo "PDK_VERSION=$PDK_VERSION" >> $GITHUB_ENV
+          PDK_DATE=$(git --git-dir $(env/bin/volare path)/volare/$PDK_FAMILY/build/$PDK_VERSION/open_pdks/.git log -1 --pretty=format:"%ad" --date=iso)
+          echo "PDK_DATE=$PDK_DATE >> $GITHUB_ENV
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ matrix.family }}-${{ env.PDK_VERSION }}
+          body: |
+            ${{ matrix.family }} variants built using open_pdks ${{ env.PDK_VERSION }} (released on ${{ env.PDK_DATE }})
+          files: |
+            default.tar.xz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           VOLARE_PATH=$(env/bin/volare path)
           PDK_FAMILY=${{ matrix.family }}
-          PDK_VERSION=$(cat $VOLARE_PATH/$PDK_FAMILY/current)
+          PDK_VERSION=$(cat $VOLARE_PATH/volare/$PDK_FAMILY/current)
           tar -C $VOLARE_PATH/$PDK_FAMILY/versions/$PDK_VERSION \
               -cvJf default.tar.xz .
           echo "PDK_VERSION=$PDK_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
I coun't find the workflow that create https://github.com/efabless/volare/releases, would it makes sense to add something like this to automate gf180mcu build and enable easier OpenLane testing?