### PR TITLE
volare/manage: skip directory when extracting

### DIFF
--- a/volare/manage.py
+++ b/volare/manage.py
@@ -260,9 +260,10 @@ def enable(
                                 final_path = os.path.join(version_directory, file.name)
                                 final_dir = os.path.dirname(final_path)
                                 mkdirp(final_dir)
-                                with tf.extractfile(file) as io:
-                                    with open(final_path, "wb") as f:
-                                        f.write(io.read())
+                                if file.isfile():
+                                    with tf.extractfile(file) as io:
+                                        with open(final_path, "wb") as f:
+                                            f.write(io.read())
 
                         for variant in variants:
                             variant_install_path = os.path.join(


### PR DESCRIPTION
`enable` currently fails with the following errors if a `tar.xz` file contains directories:
```
Traceback (most recent call last):
  File "/tmp/5/env/bin/volare", line 33, in <module>
    sys.exit(load_entry_point('volare', 'console_scripts', 'volare')())
  File "/tmp/5/env/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/tmp/5/env/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/tmp/5/env/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/tmp/5/env/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/tmp/5/env/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/proppy/src/github.com/efabless/volare/volare/manage.py", line 323, in enable_cmd
    enable(pdk_root=pdk_root, pdk=pdk, version=version)
  File "/home/proppy/src/github.com/efabless/volare/volare/manage.py", line 263, in enable
    with tf.extractfile(file) as io:
AttributeError: __enter__
```