### PR TITLE
Overhaul Package and PDK Building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,7 @@ Thumbs.db
 # Python
 __pycache__
 .mypy_cache/
-build/
-!volare/build
+/build
 /venv
 *.egg-info/
 dist/
@@ -18,3 +17,4 @@ dist/
 # Artifacts
 logs/
 pdks/
+/result

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
 mypy_path = "./mypy_stubs"
-exclude = "venv"
+exclude = "venv|build|dist"

--- a/Readme.md
+++ b/Readme.md
@@ -127,7 +127,11 @@ What's more is: if you're using a repository with a `tool_metadata.yml` file, su
 ## Building PDKs
 For special cases, i.e. you require other libraries, you'll have to build the PDK yourself, which Volare does support.
 
-It does require Docker 19.04 or higher, however.
+You'll either need Magic installed or you'll need to pass the flag `--build-magic` to build Magic ad-hoc for the PDK build, the latter option of which is only supported on Linux and requires all of Magic's dependencies to be installed. On Ubuntu, that's:
+
+```sh
+sudo apt-get install -y python3 tcsh tcl-dev tk-dev libcairo2-dev m4
+```
 
 You can invoke `volare build --help` for more options. Be aware, the built PDK won't automatically be enabled and you'll have to `volare enable` the appropriate version.
 

--- a/default.nix
+++ b/default.nix
@@ -1,18 +1,16 @@
 {
-  pkgs? import <nixpkgs> {}
+  pkgs? import <nixpkgs> {},
+  gitignore-src ? import ./nix/gitignore.nix { inherit pkgs; },
 }:
 
 with pkgs; with python3.pkgs; buildPythonPackage rec {
   name = "volare";
 
-  version_file = builtins.readFile ./volare/__init__.py;
+  version_file = builtins.readFile ./volare/__version__.py;
   version_list = builtins.match ''.+''\n__version__ = "([^"]+)"''\n.+''$'' version_file;
   version = builtins.head version_list;
 
-  src = builtins.filterSource (path: type:
-    (builtins.match ''${builtins.toString ./.}/((volare(/.+)?)|(setup.py)|(requirements(_dev)?.txt)|(Readme.md))'' path) != null &&
-    (builtins.match ''.+__pycache__.*'' path == null)
-  ) ./.;
+  src = gitignore-src.gitignoreSource ./.;
 
   doCheck = false;
   PIP_DISABLE_PIP_VERSION_CHECK = "1";

--- a/nix/gitignore.nix
+++ b/nix/gitignore.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs; let src = fetchFromGitHub { 
+  owner = "hercules-ci";
+  repo = "gitignore.nix";
+  rev = "a20de23b925fd8264fd7fad6454652e142fd7f73";
+  sha256 = "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=";
+}; in import src { inherit (pkgs) lib; }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 wheel
 black~=22.3.0
 flake8~=4.0.1
-mypy>=0.971,<1
+mypy
 types-requests
 types-PyYAML
 types-setuptools

--- a/volare/__init__.py
+++ b/volare/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .common import get_volare_home, get_current_version, get_installed_list
+from .common import get_volare_home, get_current_version, get_installed_list, Version
 from .manage import enable
 from .build import build
 

--- a/volare/__init__.py
+++ b/volare/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.6.4"
+__version__ = "0.7.0"
 
 from .common import get_volare_home
 from .manage import enable

--- a/volare/__init__.py
+++ b/volare/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022-2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.7.0"
-
-from .common import get_volare_home
+from .common import get_volare_home, get_current_version, get_installed_list
 from .manage import enable
 from .build import build
+
+from .__version__ import __version__

--- a/volare/__main__.py
+++ b/volare/__main__.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# Copyright 2022 Efabless Corporation
+# Copyright 2022-2023 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +18,7 @@ from . import __version__
 from .build import build_cmd, push_cmd
 from .manage import (
     output_cmd,
+    prune_cmd,
     path_cmd,
     list_cmd,
     list_remote_cmd,
@@ -34,6 +34,7 @@ def cli():
 
 
 cli.add_command(output_cmd)
+cli.add_command(prune_cmd)
 cli.add_command(build_cmd)
 cli.add_command(push_cmd)
 cli.add_command(path_cmd)

--- a/volare/__version__.py
+++ b/volare/__version__.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Dict
+__version__ = "0.7.0"
 
-
-class Family(object):
-    by_name: Dict[str, "Family"] = {}
-
-    def __init__(self, name: str, variants: List[str]):
-        self.name = name
-        self.variants = variants
-
-
-Family.by_name = {}
-Family.by_name["sky130"] = Family("sky130", ["sky130A", "sky130B"])
-Family.by_name["gf180mcu"] = Family("gf180mcu", ["gf180mcuA", "gf180mcuB", "gf180mcuC"])
-Family.by_name["asap7"] = Family("asap7", ["asap7"])
+if __name__ == "__main__":
+    print(__version__, end="")

--- a/volare/build/__init__.py
+++ b/volare/build/__init__.py
@@ -1,3 +1,16 @@
+# Copyright 2022-2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 import uuid
 import pathlib
@@ -13,15 +26,17 @@ from rich.progress import Progress
 
 from ..common import (
     mkdirp,
-    opt_push,
-    opt_build,
-    opt_pdk_root,
     check_version,
     get_version_dir,
     VOLARE_REPO_NAME,
     VOLARE_REPO_OWNER,
     get_date_of,
     date_to_iso8601,
+)
+from ..click_common import (
+    opt_push,
+    opt_build,
+    opt_pdk_root,
 )
 from ..families import Family
 

--- a/volare/build/__init__.py
+++ b/volare/build/__init__.py
@@ -35,6 +35,7 @@ def build(
     clear_build_artifacts: bool = True,
     include_libraries: Optional[List[str]] = None,
     use_repo_at: Optional[List[str]] = None,
+    build_magic: bool = False,
 ):
     use_repos = {}
     if use_repo_at is not None:
@@ -53,6 +54,7 @@ def build(
         "clear_build_artifacts": clear_build_artifacts,
         "include_libraries": include_libraries,
         "using_repos": use_repos,
+        "build_magic": build_magic,
     }
 
     build_module = importlib.import_module(f".{pdk}", package=__name__)
@@ -81,6 +83,7 @@ def build_cmd(
     tool_metadata_file_path,
     version,
     use_repo_at,
+    build_magic,
 ):
     """
     Builds the requested PDK.
@@ -102,6 +105,7 @@ def build_cmd(
         clear_build_artifacts=clear_build_artifacts,
         include_libraries=include_libraries,
         use_repo_at=use_repo_at,
+        build_magic=build_magic,
     )
 
 

--- a/volare/build/asap7.py
+++ b/volare/build/asap7.py
@@ -1,3 +1,16 @@
+# Copyright 2022-2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 import shutil
 import subprocess

--- a/volare/build/asap7.py
+++ b/volare/build/asap7.py
@@ -131,6 +131,7 @@ def build(
     clear_build_artifacts: bool = True,
     include_libraries: Optional[List[str]] = None,
     using_repos: Optional[Dict[str, str]] = None,
+    build_magic: bool = False,
 ):
     if using_repos is None:
         using_repos = {}

--- a/volare/build/gf180mcu.py
+++ b/volare/build/gf180mcu.py
@@ -1,3 +1,16 @@
+# Copyright 2022-2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 import io
 import json

--- a/volare/build/git_multi_clone.py
+++ b/volare/build/git_multi_clone.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2022 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/volare/build/magic.py
+++ b/volare/build/magic.py
@@ -1,3 +1,16 @@
+# Copyright 2022-2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 import shutil
 import tarfile

--- a/volare/build/magic.py
+++ b/volare/build/magic.py
@@ -1,0 +1,92 @@
+import os
+import shutil
+import tarfile
+import tempfile
+import platform
+import subprocess
+from typing import Callable, TypeVar
+
+import requests
+from rich.console import Console
+
+from ..common import mkdirp
+
+T = TypeVar("T")
+
+
+def with_magic(
+    magic_tag: str,
+    callable: Callable[[str], T],
+    build_magic: bool = False,
+) -> T:
+    if not build_magic:
+        if magic_bin := shutil.which("magic"):
+            return callable(magic_bin)
+        else:
+            raise ValueError("Magic not found in PATH.")
+    else:
+        if platform.system() != "Linux":
+            raise RuntimeError(
+                "Building magic is not supported on non-Linux platforms."
+            )
+    with tempfile.TemporaryDirectory() as d:
+        magic_dir = os.path.join(d, "src")
+        magic_tgz = os.path.join(d, "magic_src.tgz")
+        magic_pfx = os.path.join(d, "pfx")
+        magic_bin = os.path.join(magic_pfx, "bin", "magic")
+
+        console = Console()
+        console.status("Downloading Magic repo…")
+        magic_req = requests.get(
+            f"https://github.com/RTimothyEdwards/magic/tarball/{magic_tag}",
+            allow_redirects=True,
+        )
+        with open(magic_tgz, "wb") as f:
+            f.write(magic_req.content)
+        console.log("Downloaded Magic repo.")
+
+        with tarfile.open(magic_tgz, mode="r:*") as tf:
+            for _, file in enumerate(tf.getmembers()):
+                if file.isdir():
+                    continue
+                components = file.name.split(os.path.sep)
+                if components[0] == "":
+                    components = components[1:]
+                components = components[1:]
+                final_path = os.path.join(magic_dir, os.path.sep.join(components))
+                io = tf.extractfile(file)
+                final_dir = os.path.dirname(final_path)
+                mkdirp(final_dir)
+                with open(final_path, "wb") as f:
+                    f.write(io.read())
+
+                os.chmod(final_path, file.mode)
+
+        try:
+            with console.status("Building Magic…"):
+                subprocess.check_output(
+                    ["sh", "./configure", f"--prefix={magic_pfx}"],
+                    cwd=magic_dir,
+                    stderr=subprocess.STDOUT,
+                )
+
+                subprocess.check_output(
+                    ["make", "-j", str(os.cpu_count())],
+                    cwd=magic_dir,
+                    stderr=subprocess.STDOUT,
+                )
+
+                subprocess.check_output(
+                    ["make", "install"],
+                    cwd=magic_dir,
+                    stderr=subprocess.STDOUT,
+                )
+
+            if not os.path.exists(magic_bin):
+                raise RuntimeError("Failed to build Magic.")
+
+            console.log("Done building Magic.")
+        except subprocess.SubprocessError as e:
+            console.log(e.stdout)
+
+        return callable(magic_bin)

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -2,7 +2,6 @@ import os
 import io
 import json
 import venv
-import uuid
 import shutil
 import subprocess
 from datetime import datetime
@@ -14,6 +13,7 @@ from rich.console import Console
 from rich.progress import Progress
 
 from .git_multi_clone import GitMultiClone
+from .magic import with_magic
 from ..common import (
     get_logs_dir,
     get_version_dir,
@@ -203,7 +203,7 @@ def build_sky130_timing(build_directory, sky130_path, log_dir, jobs=1):
 
         def do_submodule(submodule: str):
             submodule_cleaned = submodule.strip("/.").replace("/", "_")
-            console.log(f"Processing {submodule}…")
+            console.log(f"Generating timing files for {submodule}…")
             with open(f"{log_dir}/timing.{submodule_cleaned}.log", "w") as out:
                 subprocess.check_call(
                     [
@@ -244,112 +244,73 @@ def build_sky130_timing(build_directory, sky130_path, log_dir, jobs=1):
 
 
 def build_variants(
-    sram, build_directory, open_pdks_path, sky130_path, magic_tag, log_dir, jobs=1
+    magic_bin,
+    sram,
+    build_directory,
+    open_pdks_path,
+    sky130_path,
+    log_dir,
+    jobs=1,
 ):
     try:
+        pdk_root_abs = os.path.abspath(build_directory)
         console = Console()
 
-        magic_tag = magic_tag or MAGIC_DEFAULT_TAG
-
-        console.log(f"Using magic {magic_tag}…")
-
-        magic_image = f"efabless/openlane-tools:magic-{magic_tag}-centos-7"
-
-        subprocess.check_call(["docker", "pull", magic_image])
-
-        docker_ids = set()
-
-        def docker_run_sh(*args, log_to):
-            nonlocal docker_ids
+        def run_sh(script, log_to):
             output_file = open(log_to, "w")
-            container_id = str(uuid.uuid4())
-            docker_ids.add(container_id)
-            args = list(args)
-            pdk_root_abs = os.path.abspath(build_directory)
             try:
                 subprocess.check_call(
-                    [
-                        "docker",
-                        "run",
-                        "--name",
-                        container_id,
-                        "--rm",
-                        "-e",
-                        f"PDK_ROOT={pdk_root_abs}",
-                        "-v",
-                        f"{pdk_root_abs}:{pdk_root_abs}",
-                        "-e",
-                        f"SKY130_PATH={sky130_path}",
-                        "-v",
-                        f"{sky130_path}:{sky130_path}",
-                        "-e",
-                        f"OPEN_PDKS_PATH={open_pdks_path}",
-                        "-v",
-                        f"{open_pdks_path}:{open_pdks_path}",
-                        "-w",
-                        f"{pdk_root_abs}",
-                        magic_image,
-                        "sh",
-                        "-c",
-                    ]
-                    + args,
+                    ["sh", "-c", script],
+                    cwd=open_pdks_path,
                     stdout=output_file,
                     stderr=output_file,
+                    stdin=open(os.devnull),
                 )
             except subprocess.CalledProcessError as e:
                 console.log(
                     f"An error occurred while building the PDK. Check {log_to} for more information."
                 )
-                docker_ids.remove(container_id)
                 raise e
-            docker_ids.remove(container_id)
 
         sram_opt = "--enable-sram-sky130" if sram else ""
+        magic_dirname = os.path.dirname(magic_bin)
 
-        interrupted = None
-        try:
-            console.log("Configuring open_pdks…")
-            docker_run_sh(
+        with console.status("Configuring open_pdks…"):
+            run_sh(
                 f"""
                     set -e
-                    cd $OPEN_PDKS_PATH
-                    ./configure --enable-sky130-pdk=$SKY130_PATH/libraries {sram_opt}
+                    export PATH="{magic_dirname}:$PATH"
+                    ./configure --enable-sky130-pdk={sky130_path}/libraries {sram_opt}
                 """,
                 log_to=os.path.join(log_dir, "config.log"),
             )
-            console.log("Done.")
+        console.log("Configured open_pdks.")
 
-            console.log("Building variants using open_pdks…")
-            docker_run_sh(
+        with console.status("Building variants using open_pdks…"):
+            run_sh(
                 f"""
                     set -e
-                    cd $OPEN_PDKS_PATH
                     export LC_ALL=en_US.UTF-8
+                    export PATH="{magic_dirname}:$PATH"
                     make -j{jobs}
-                    make SHARED_PDKS_PATH=$PDK_ROOT install
+                    make 'SHARED_PDKS_PATH={pdk_root_abs}' install
                 """,
                 log_to=os.path.join(log_dir, "install.log"),
             )
-        except KeyboardInterrupt as e:
-            interrupted = e
-            console.log("Stopping on keyboard interrupt…")
-            console.log("Killing docker containers…")
-            for id in docker_ids:
-                subprocess.call(["docker", "kill", id])
+        console.log("Built PDK variants.")
 
-        console.log("Fixing file ownership…")
-        docker_run_sh(
-            """
+        with console.status("Fixing file ownership…"):
+            run_sh(
+                f"""
                 set -e
-                OWNERSHIP="$(stat -c "%u:%g" $PDK_ROOT)"
-                chown -R $OWNERSHIP $PDK_ROOT
-            """,
-            log_to=os.path.join(log_dir, "ownership.log"),
-        )
-        if interrupted is not None:
-            raise interrupted
-        else:
-            console.log("Done.")
+                OWNERSHIP="$(stat -c "%u:%g" "{pdk_root_abs}")"
+                chown -R $OWNERSHIP "{pdk_root_abs}"
+                """,
+                log_to=os.path.join(log_dir, "ownership.log"),
+            )
+        console.log("Fixed file ownership.")
+
+        console.log("Done.")
 
     except subprocess.CalledProcessError as e:
         print(e)
@@ -396,6 +357,7 @@ def build(
     clear_build_artifacts: bool = True,
     include_libraries: Optional[List[str]] = None,
     using_repos: Optional[Dict[str, str]] = None,
+    build_magic: bool = False,
 ):
     if include_libraries is None or len(include_libraries) == 0:
         include_libraries = [
@@ -423,8 +385,19 @@ def build(
         include_libraries, build_directory, sky130_tag, jobs, using_repos.get("sky130")
     )
     build_sky130_timing(build_directory, sky130_path, log_dir, jobs)
-    build_variants(
-        sram, build_directory, open_pdks_path, sky130_path, magic_tag, log_dir, jobs
+
+    with_magic(
+        magic_tag,
+        lambda magic_bin: build_variants(
+            magic_bin,
+            sram,
+            build_directory,
+            open_pdks_path,
+            sky130_path,
+            log_dir,
+            jobs,
+        ),
+        build_magic=build_magic,
     )
     install_sky130(build_directory, pdk_root, version)
 

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -1,3 +1,16 @@
+# Copyright 2022-2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 import io
 import json

--- a/volare/click_common.py
+++ b/volare/click_common.py
@@ -1,0 +1,98 @@
+# Copyright 2022-2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from functools import partial
+from typing import Callable
+
+import click
+
+from .common import VOLARE_RESOLVED_HOME, VOLARE_REPO_OWNER, VOLARE_REPO_NAME
+
+opt = partial(click.option, show_default=True)
+
+
+def opt_pdk_root(function: Callable):
+    function = click.option(
+        "--pdk",
+        required=False,
+        default=os.getenv("PDK_FAMILY") or "sky130",
+        help="The PDK family to install",
+        show_default=True,
+    )(function)
+    function = click.option(
+        "--pdk-root",
+        required=False,
+        default=VOLARE_RESOLVED_HOME,
+        help="Path to the PDK root",
+        show_default=True,
+    )(function)
+    return function
+
+
+def opt_build(function: Callable):
+    function = opt(
+        "-l",
+        "--include-libraries",
+        multiple=True,
+        default=None,
+        help="Libraries to include in the build. You can use -l multiple times to include multiple libraries. Pass 'all' to include all of them. A default of 'None' uses a default set for the particular PDK.",
+    )(function)
+    function = opt(
+        "-j",
+        "--jobs",
+        default=1,
+        help="Specifies the number of commands to run simultaneously.",
+    )(function)
+    function = opt("--sram/--no-sram", default=True, help="Enable or disable sram")(
+        function
+    )
+    function = opt(
+        "--clear-build-artifacts/--keep-build-artifacts",
+        default=False,
+        help="Whether or not to remove the build artifacts. Keeping the build artifacts is useful when testing.",
+    )(function)
+    function = opt(
+        "-r",
+        "--use-repo-at",
+        default=None,
+        multiple=True,
+        hidden=True,
+        type=str,
+        help="Use this repository instead of cloning and checking out, in the format repo_name=/path/to/repo. You can pass it multiple times to replace multiple repos. This feature is intended for volare and PDK developers.",
+    )(function)
+    function = opt(
+        "--build-magic/--use-system-magic",
+        default=False,
+        help="Whether to attempt to build Magic from source or use Magic from PATH for PDKs that may need Magic.",
+    )(function)
+    return function
+
+
+def opt_push(function: Callable):
+    function = opt("-o", "--owner", default=VOLARE_REPO_OWNER, help="Repository Owner")(
+        function
+    )
+    function = opt("-r", "--repository", default=VOLARE_REPO_NAME, help="Repository")(
+        function
+    )
+    function = opt(
+        "-t",
+        "--token",
+        default=os.getenv("GITHUB_TOKEN"),
+        help="Github Token",
+    )(function)
+    function = opt(
+        "--pre/--prod", default=False, help="Push as pre-release or production"
+    )(function)
+    return function

--- a/volare/common.py
+++ b/volare/common.py
@@ -84,7 +84,7 @@ class Version(object):
         return self.name
 
     @classmethod
-    def from_github(Self) -> Dict[str, List["Version"]]:
+    def _from_github(Self) -> Dict[str, List["Version"]]:
         response_str = requests.get(
             f"{VOLARE_REPO_API}/releases", params={"per_page": 100}
         ).content.decode("utf8")

--- a/volare/common.py
+++ b/volare/common.py
@@ -182,6 +182,11 @@ def opt_build(function: Callable):
         type=str,
         help="Use this repository instead of cloning and checking out, in the format repo_name=/path/to/repo. You can pass it multiple times to replace multiple repos. This feature is intended for volare and PDK developers.",
     )(function)
+    function = opt(
+        "--build-magic/--use-system-magic",
+        default=False,
+        help="Whether to attempt to build Magic from source or use Magic from PATH for PDKs that may need Magic.",
+    )(function)
     return function
 
 

--- a/volare/manage.py
+++ b/volare/manage.py
@@ -57,7 +57,7 @@ def print_installed_list(
     versions = installed_list
 
     try:
-        all_remote_versions = Version.from_github()
+        all_remote_versions = Version._from_github()
         remote_versions = all_remote_versions.get(pdk) or []
         remote_version_dict = {rv.name: rv for rv in remote_versions}
         for installed in installed_list:
@@ -186,7 +186,7 @@ def list_remote_cmd(pdk_root, pdk):
     """Lists PDK versions that are remotely available. JSON if not outputting to a tty."""
 
     try:
-        all_versions = Version.from_github()
+        all_versions = Version._from_github()
         pdk_versions = all_versions.get(pdk) or []
 
         if sys.stdout.isatty():

--- a/volare/manage.py
+++ b/volare/manage.py
@@ -241,7 +241,7 @@ def enable(
         if status == 404:
             console.print(f"Version {version} not found either locally or remotely.")
             if build_if_not_found:
-                console.print("Attempting to build...")
+                console.print("Attempting to build…")
                 build(pdk_root=pdk_root, pdk=pdk, version=version, **build_kwargs)
                 if also_push:
                     push(pdk_root=pdk_root, pdk=pdk, version=version, **push_kwargs)
@@ -254,6 +254,7 @@ def enable(
             with tempfile.TemporaryDirectory(suffix=".volare") as tarball_directory:
                 tarball_path = os.path.join(tarball_directory, f"{version}.tar.xz")
                 with requests.get(link, stream=True) as r:
+                    assert isinstance(r, requests.Response)
                     with rich.progress.Progress() as p:
                         task = p.add_task(
                             f"Downloading pre-built tarball for {version}…",
@@ -270,6 +271,8 @@ def enable(
                             p.update(task, total=len(tf.getmembers()))
                             for i, file in enumerate(tf.getmembers()):
                                 p.update(task, completed=i + 1)
+                                if file.isdir():
+                                    continue
                                 final_path = os.path.join(version_directory, file.name)
                                 final_dir = os.path.dirname(final_path)
                                 mkdirp(final_dir)
@@ -367,6 +370,7 @@ def enable_or_build_cmd(
     also_push,
     version,
     use_repo_at,
+    build_magic,
 ):
     """
     Attempts to activate a given PDK version. If the version is not found locally or remotely,
@@ -388,6 +392,7 @@ def enable_or_build_cmd(
             "sram": sram,
             "clear_build_artifacts": clear_build_artifacts,
             "use_repo_at": use_repo_at,
+            "build_magic": build_magic,
         },
         push_kwargs={
             "owner": owner,


### PR DESCRIPTION
+ Add option to either use system magic or build magic (Linux-only) for PDK builds
+ Use gitignoreSource for Nix
+ Add a `prune` command to delete currently unused PDKs
+ `get_current_version`, `get_installed_list` and `Version` added to API
~ Add copyright headers for all Python files
~ Update mypy
~ Internal restructuring- `click_common` now separate from `common`, with some functions in `cli` moved to `common`
- Remove all use of Docker from PDK building