### PR TITLE
Use `--with-reference` for consistency when building the pdk

### DIFF
--- a/volare/__version__.py
+++ b/volare/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/volare/build/gf180mcu.py
+++ b/volare/build/gf180mcu.py
@@ -157,7 +157,7 @@ def build_variants(
                 f"""
                     set -e
                     export PATH="{magic_dirname}:$PATH"
-                    ./configure --enable-gf180mcu-pdk {' '.join(library_flags)}
+                    ./configure --enable-gf180mcu-pdk {' '.join(library_flags)} --with-reference
                 """,
                 log_to=os.path.join(log_dir, "config.log"),
             )

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -293,7 +293,7 @@ def build_variants(
                 f"""
                     set -e
                     export PATH="{magic_dirname}:$PATH"
-                    ./configure --enable-sky130-pdk={sky130_path}/libraries {sram_opt}
+                    ./configure --enable-sky130-pdk={sky130_path}/libraries {sram_opt} --with-reference
                 """,
                 log_to=os.path.join(log_dir, "config.log"),
             )


### PR DESCRIPTION
This ensures that the sources' versions in gf180mc.json and sky130.json are used.

Note:
As far as I understand, this wasn't the default behavior in open_pdks - this commit ids in the json files where not used - but this is what I would expect to happen in the first place.

--
Depends on https://github.com/RTimothyEdwards/open_pdks/pull/373