### PR TITLE
Switch to ZSTD + Selective Library Installation Support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -68,7 +68,7 @@ In its current inception, volare supports builds of **sky130** and **gf180mcu** 
 |sky130_fd_pr|gf180mcu_fd_pr|
 |sky130_fd_sc_hd|gf180mcu_fd_sc_mcu7t5v0|
 |sky130_fd_sc_hvl|gf180mcu_fd_sc_mcu9t5v0|
-|sky130 sram modules|gf180mcu_fd_bd_sram|
+|sky130 sram modules|gf180mcu_fd_ip_sram|
 
 All builds are identified by their **open_pdks** commit hash.
 

--- a/default.nix
+++ b/default.nix
@@ -21,5 +21,6 @@ with pkgs; with python3.pkgs; buildPythonPackage rec {
     rich
     requests
     pcpp
+    zstandard
   ];
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml>=5,<7
 rich>=12,<13
 requests>=2.27.0,<3
 pcpp>=1.2,<2
+zstandard>=0.19.0,<1

--- a/volare/__main__.py
+++ b/volare/__main__.py
@@ -19,6 +19,7 @@ from .build import build_cmd, push_cmd
 from .manage import (
     output_cmd,
     prune_cmd,
+    rm_cmd,
     path_cmd,
     list_cmd,
     list_remote_cmd,
@@ -35,6 +36,7 @@ def cli():
 
 cli.add_command(output_cmd)
 cli.add_command(prune_cmd)
+cli.add_command(rm_cmd)
 cli.add_command(build_cmd)
 cli.add_command(push_cmd)
 cli.add_command(path_cmd)
@@ -44,7 +46,6 @@ cli.add_command(enable_cmd)
 cli.add_command(enable_or_build_cmd)
 
 try:
-    import lzma  # noqa: F401
     import ssl  # noqa: F401
 except ModuleNotFoundError as e:
     print(

--- a/volare/__version__.py
+++ b/volare/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.7.3"
+__version__ = "0.8.0"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/volare/build/asap7.py
+++ b/volare/build/asap7.py
@@ -140,7 +140,6 @@ def build(
     pdk_root: str,
     version: str,
     jobs: int = 1,
-    sram: bool = True,
     clear_build_artifacts: bool = True,
     include_libraries: Optional[List[str]] = None,
     using_repos: Optional[Dict[str, str]] = None,

--- a/volare/build/gf180mcu.py
+++ b/volare/build/gf180mcu.py
@@ -230,22 +230,15 @@ def build(
     pdk_root: str,
     version: str,
     jobs: int = 1,
-    sram: bool = True,
     clear_build_artifacts: bool = True,
     include_libraries: Optional[List[str]] = None,
     using_repos: Optional[Dict[str, str]] = None,
     build_magic: bool = False,
 ):
-    if include_libraries is None or len(include_libraries) == 0:
-        include_libraries = [
-            "gf180mcu_fd_sc_mcu7t5v0",
-            "gf180mcu_fd_sc_mcu9t5v0",
-            "gf180mcu_fd_io",
-            "gf180mcu_fd_pr",
-        ]
+    if include_libraries is None:
+        include_libraries = Family.by_name["gf180mcu"].default_includes
 
-    if sram:
-        include_libraries.append("gf180mcu_fd_bd_sram")
+    include_libraries = set(include_libraries)
 
     if using_repos is None:
         using_repos = {}
@@ -267,7 +260,7 @@ def build(
         magic_tag,
         lambda magic_bin: build_variants(
             magic_bin,
-            include_libraries,
+            list(include_libraries),
             build_directory,
             open_pdks_path,
             log_dir,

--- a/volare/build/gf180mcu.py
+++ b/volare/build/gf180mcu.py
@@ -121,7 +121,9 @@ LIB_FLAG_MAP = {
     "gf180mcu_fd_sc_mcu7t5v0": "--enable-sc-7t5v0-gf180mcu",
     "gf180mcu_fd_sc_mcu9t5v0": "--enable-sc-9t5v0-gf180mcu",
     "gf180mcu_fd_io": "--enable-io-gf180mcu",
-    "gf180mcu_fd_bd_sram": "--enable-sram-gf180mcu",
+    "gf180mcu_fd_ip_sram": "--enable-sram-gf180mcu",
+    "gf180mcu_osu_sc_gp12t3v3": "--enable-osu-sc-gf180mcu",
+    "gf180mcu_osu_sc_gp9t3v3": "--enable-osu-sc-gf180mcu",
 }
 
 
@@ -149,7 +151,7 @@ def build_variants(
                 )
                 raise e
 
-        library_flags = [LIB_FLAG_MAP[library] for library in include_libraries]
+        library_flags = set([LIB_FLAG_MAP[library] for library in include_libraries])
         magic_dirname = os.path.dirname(magic_bin)
 
         with console.status("Configuring open_pdks…"):

--- a/volare/build/gf180mcu.py
+++ b/volare/build/gf180mcu.py
@@ -236,9 +236,9 @@ def build(
     build_magic: bool = False,
 ):
     if include_libraries is None:
-        include_libraries = Family.by_name["gf180mcu"].default_includes
-
-    include_libraries = set(include_libraries)
+        include_libraries = Family.by_name["gf180mcu"].default_includes.copy()
+    if "all" in include_libraries:
+        include_libraries = list(LIB_FLAG_MAP.keys())
 
     if using_repos is None:
         using_repos = {}

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -366,19 +366,13 @@ def build(
     pdk_root: str,
     version: str,
     jobs: int = 1,
-    sram: bool = True,
     clear_build_artifacts: bool = True,
     include_libraries: Optional[List[str]] = None,
     using_repos: Optional[Dict[str, str]] = None,
     build_magic: bool = False,
 ):
-    if include_libraries is None or len(include_libraries) == 0:
-        include_libraries = [
-            "sky130_fd_sc_hd",
-            "sky130_fd_sc_hvl",
-            "sky130_fd_io",
-            "sky130_fd_pr",
-        ]
+    if include_libraries is None:
+        include_libraries = Family.by_name["sky130"].default_includes
 
     if using_repos is None:
         using_repos = {}
@@ -403,7 +397,7 @@ def build(
         magic_tag,
         lambda magic_bin: build_variants(
             magic_bin,
-            sram,
+            "sky130_sram_macros" in include_libraries,
             build_directory,
             open_pdks_path,
             sky130_path,

--- a/volare/click_common.py
+++ b/volare/click_common.py
@@ -46,7 +46,7 @@ def opt_build(function: Callable):
         "--include-libraries",
         multiple=True,
         default=None,
-        help="Libraries to include in the build. You can use -l multiple times to include multiple libraries. Pass 'all' to include all of them. A default of 'None' uses a default set for the particular PDK.",
+        help="Libraries to include. You can use -l multiple times to include multiple libraries. Pass 'all' to include all of them. A default of 'None' uses a default set for the particular PDK.",
     )(function)
     function = opt(
         "-j",
@@ -54,9 +54,12 @@ def opt_build(function: Callable):
         default=1,
         help="Specifies the number of commands to run simultaneously.",
     )(function)
-    function = opt("--sram/--no-sram", default=True, help="Enable or disable sram")(
-        function
-    )
+    function = opt(
+        "--sram/--no-sram",
+        default=True,
+        hidden=True,
+        expose_value=False,
+    )(function)
     function = opt(
         "--clear-build-artifacts/--keep-build-artifacts",
         default=False,

--- a/volare/common.py
+++ b/volare/common.py
@@ -337,5 +337,6 @@ def get_date_of(opdks_commit: str) -> Optional[datetime]:
 def get_installed_list(pdk_root: str, pdk: str) -> List[Version]:
     return Version.get_all_installed(pdk_root, pdk)
 
+
 def get_current_version(pdk_root: str, pdk: str) -> Optional[str]:
     return _get_current_version(pdk_root, pdk)

--- a/volare/families.py
+++ b/volare/families.py
@@ -17,12 +17,34 @@ from typing import List, Dict
 class Family(object):
     by_name: Dict[str, "Family"] = {}
 
-    def __init__(self, name: str, variants: List[str]):
+    def __init__(self, name: str, variants: List[str], default_includes: List[str]):
         self.name = name
         self.variants = variants
+        self.default_includes = default_includes
 
 
 Family.by_name = {}
-Family.by_name["sky130"] = Family("sky130", ["sky130A", "sky130B"])
-Family.by_name["gf180mcu"] = Family("gf180mcu", ["gf180mcuA", "gf180mcuB", "gf180mcuC"])
-Family.by_name["asap7"] = Family("asap7", ["asap7"])
+Family.by_name["sky130"] = Family(
+    "sky130",
+    ["sky130A", "sky130B"],
+    [
+        "sky130_fd_io",
+        "sky130_fd_pr",
+        "sky130_fd_sc_hd",
+        "sky130_fd_sc_hvl",
+        "sky130_ml_xx_hd",
+        "sky130_sram_macros",
+    ],
+)
+Family.by_name["gf180mcu"] = Family(
+    "gf180mcu",
+    ["gf180mcuA", "gf180mcuB", "gf180mcuC"],
+    [
+        "gf180mcu_fd_io",
+        "gf180mcu_fd_pr",
+        "gf180mcu_fd_sc_mcu7t5v0",
+        "gf180mcu_fd_sc_mcu9t5v0",
+        "gf180mcu_fd_bd_sram",
+    ],
+)
+Family.by_name["asap7"] = Family("asap7", ["asap7"], default_includes=[])

--- a/volare/families.py
+++ b/volare/families.py
@@ -44,7 +44,7 @@ Family.by_name["gf180mcu"] = Family(
         "gf180mcu_fd_pr",
         "gf180mcu_fd_sc_mcu7t5v0",
         "gf180mcu_fd_sc_mcu9t5v0",
-        "gf180mcu_fd_bd_sram",
+        "gf180mcu_fd_ip_sram",
     ],
 )
 Family.by_name["asap7"] = Family("asap7", ["asap7"], default_includes=[])


### PR DESCRIPTION
+ Upload each standard cell library to its own tarball when pushing
+ Allow `enable` to pick specific standard cell libraries from the ones uploaded
+ Add command `volare rm` to remove installations
~ Switch compression to ZSTD (XZ still used as a fallback when getting new PDKs)
~ Some internal class restructuring
~ Make interrupted downloads/builds more resilient
- Drop `--sram` flag: now listed as one of the standard cell libraries