### PR TITLE
Better Multi-Version Handling

### DIFF
--- a/volare/__init__.py
+++ b/volare/__init__.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from .manage import VersionNotFound, enable
 from .common import get_volare_home, get_current_version, get_installed_list, Version
-from .manage import enable
 from .build import build
 
 from .__version__ import __version__

--- a/volare/__main__.py
+++ b/volare/__main__.py
@@ -12,20 +12,266 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
-import click
+import json
+import requests
 
-from . import __version__
-from .build import build_cmd, push_cmd
-from .manage import (
-    output_cmd,
-    prune_cmd,
-    rm_cmd,
-    path_cmd,
-    list_cmd,
-    list_remote_cmd,
-    enable_cmd,
-    enable_or_build_cmd,
+import click
+from rich.console import Console
+
+from .__version__ import __version__
+from .common import (
+    Version,
+    check_version,
+    get_installed_list,
 )
+from .click_common import (
+    opt,
+    opt_build,
+    opt_push,
+    opt_pdk_root,
+)
+from .manage import (
+    print_installed_list,
+    print_remote_list,
+    enable,
+)
+from .build import (
+    build_cmd,
+    push_cmd,
+)
+
+
+@click.command("output")
+@opt_pdk_root
+def output_cmd(pdk_root, pdk):
+    """Outputs the currently enabled PDK version.
+
+    If not outputting to a tty, the output is either the version string
+    unembellished, or, if no current version is enabled, an empty output with an
+    exit code of 1.
+    """
+
+    version = Version.get_current(pdk_root, pdk)
+    if sys.stdout.isatty():
+        if version is None:
+            print(f"No version of the PDK {pdk} is currently enabled at {pdk_root}.")
+            print(
+                "Invoke volare --help for assistance installing and enabling versions."
+            )
+            exit(1)
+        else:
+            print(f"Installed: {pdk} v{version.name}")
+            print(
+                "Invoke volare --help for assistance installing and enabling versions."
+            )
+    else:
+        if version is None:
+            exit(1)
+        else:
+            print(version.name, end="")
+
+
+@click.command("prune")
+@opt_pdk_root
+@click.option(
+    "--yes",
+    is_flag=True,
+    callback=lambda c, _, v: not v and c.abort(),
+    expose_value=False,
+    prompt="Are you sure? This will delete all non-enabled versions of the PDK from your computer.",
+)
+def prune_cmd(pdk_root, pdk):
+    """Removes all PDKs other than, if it exists, the one currently in use."""
+    pdk_versions = get_installed_list(pdk_root, pdk)
+    for version in pdk_versions:
+        if version.is_current(pdk_root):
+            continue
+        try:
+            version.uninstall()
+            print(f"Deleted {version}.")
+        except Exception as e:
+            print(f"Failed to delete {version}: {e}", file=sys.stderr)
+
+
+@click.command("rm")
+@opt_pdk_root
+@click.option(
+    "--yes",
+    is_flag=True,
+    callback=lambda c, _, v: not v and c.abort(),
+    expose_value=False,
+    prompt="Are you sure? This will delete this version of the PDK from your computer.",
+)
+@click.argument("version", required=False)
+def rm_cmd(pdk_root, pdk, version):
+    """Removes the PDK version specified."""
+    version_object = Version(version, pdk)
+    try:
+        version_object.uninstall(pdk_root)
+        print(f"Deleted {version}.")
+    except Exception as e:
+        print(f"Failed to delete: {e}", file=sys.stderr)
+        exit(1)
+
+
+@click.command("ls")
+@opt_pdk_root
+def list_cmd(pdk_root, pdk):
+    """Lists PDK versions that are locally installed. JSON if not outputting to a tty."""
+
+    pdk_versions = get_installed_list(pdk_root, pdk)
+
+    if sys.stdout.isatty():
+        console = Console()
+        print_installed_list(pdk_root, pdk, console, pdk_versions)
+    else:
+        print(json.dumps([version.name for version in pdk_versions]), end="")
+
+
+@click.command("ls-remote")
+@opt_pdk_root
+def list_remote_cmd(pdk_root, pdk):
+    """Lists PDK versions that are remotely available. JSON if not outputting to a tty."""
+
+    try:
+        all_versions = Version._from_github()
+        pdk_versions = all_versions.get(pdk) or []
+
+        if sys.stdout.isatty():
+            console = Console()
+            print_remote_list(pdk_root, pdk, console, pdk_versions)
+        else:
+            print(json.dumps([version.name for version in pdk_versions]), end="")
+    except requests.exceptions.ConnectionError:
+        if sys.stdout.isatty():
+            console = Console()
+            console.print(
+                "[red]You don't appear to be connected to the Internet. ls-remote cannot be used."
+            )
+        else:
+            print("Failed to connect to remote server", file=sys.stderr)
+        sys.exit(-1)
+
+
+@click.command("path")
+@opt_pdk_root
+@click.argument("version", required=False)
+def path_cmd(pdk_root, pdk, version):
+    """Prints the path of a specific pdk version installation."""
+    version = Version(version, pdk)
+    print(version.get_dir(pdk_root), end="")
+
+
+@click.command("enable")
+@opt_pdk_root
+@click.option(
+    "-f",
+    "--metadata-file",
+    "tool_metadata_file_path",
+    default=None,
+    help="Explicitly define a tool metadata file instead of searching for a metadata file",
+)
+@click.option(
+    "-l",
+    "--include-libraries",
+    multiple=True,
+    default=None,
+    help="Libraries to include. You can use -l multiple times to include multiple libraries. Pass 'all' to include all of them. A default of 'None' uses a default set for the particular PDK.",
+)
+@click.argument("version", required=False)
+def enable_cmd(pdk_root, pdk, tool_metadata_file_path, version, include_libraries):
+    """
+    Activates a given installed PDK version.
+
+    Parameters: <version> (Optional)
+
+    If a version is not given, and you run this in the top level directory of
+    tools with a tool_metadata.yml file, for example OpenLane or DFFRAM,
+    the appropriate version will be enabled automatically.
+    """
+    if include_libraries == ():
+        include_libraries = None
+
+    console = Console()
+    version = check_version(version, tool_metadata_file_path, console)
+    try:
+        enable(
+            pdk_root=pdk_root,
+            pdk=pdk,
+            version=version,
+            include_libraries=include_libraries,
+            console=console,
+        )
+    except Exception as e:
+        console.print(f"[red]{e}")
+        exit(-1)
+
+
+@click.command("enable_or_build", hidden=True)
+@opt_pdk_root
+@opt_push
+@opt_build
+@opt("--also-push/--dont-push", default=False, help="Also push.")
+@click.option(
+    "-f",
+    "--metadata-file",
+    "tool_metadata_file_path",
+    default=None,
+    help="Explicitly define a tool metadata file instead of searching for a metadata file",
+)
+@click.argument("version")
+def enable_or_build_cmd(
+    include_libraries,
+    jobs,
+    pdk_root,
+    pdk,
+    owner,
+    repository,
+    token,
+    pre,
+    clear_build_artifacts,
+    tool_metadata_file_path,
+    also_push,
+    version,
+    use_repo_at,
+    build_magic,
+):
+    """
+    Attempts to activate a given PDK version. If the version is not found locally or remotely,
+    it will instead attempt to build said version.
+
+    Parameters: <version>
+    """
+    if include_libraries == ():
+        include_libraries = None
+
+    console = Console()
+    version = check_version(version, tool_metadata_file_path, console)
+    try:
+        enable(
+            pdk_root=pdk_root,
+            pdk=pdk,
+            version=version,
+            build_if_not_found=True,
+            also_push=also_push,
+            build_kwargs={
+                "include_libraries": include_libraries,
+                "jobs": jobs,
+                "clear_build_artifacts": clear_build_artifacts,
+                "use_repo_at": use_repo_at,
+                "build_magic": build_magic,
+            },
+            push_kwargs={
+                "owner": owner,
+                "repository": repository,
+                "token": token,
+                "pre": pre,
+            },
+            include_libraries=include_libraries,
+        )
+    except Exception as e:
+        console.print(f"[red]{e}")
+        exit(-1)
 
 
 @click.group()

--- a/volare/__version__.py
+++ b/volare/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/volare/build/__init__.py
+++ b/volare/build/__init__.py
@@ -132,13 +132,19 @@ def push(
     repository=VOLARE_REPO_NAME,
     token=os.getenv("GITHUB_TOKEN"),
     pre=False,
+    push_libraries=None,
 ):
     console = Console()
+
+    if push_libraries is None:
+        push_libraries = Family.by_name["PDK"].all_libraries
+
+    library_list = set(push_libraries)
 
     version_directory = get_version_dir(pdk_root, pdk, version)
     if not os.path.isdir(version_directory):
         console.print("[red]Version not found.")
-        exit(os.EX_NOINPUT)
+        exit(-1)
 
     tempdir = tempfile.gettempdir()
     tarball_directory = os.path.join(tempdir, "volare", f"{uuid.uuid4()}", version)
@@ -156,6 +162,8 @@ def push(
             path_components = relative.split(os.sep)
             if path_components[1] == "libs.ref":
                 lib = path_components[2]
+                if lib not in library_list:
+                    continue
                 collections[lib] = collections.get(lib) or []
                 collections[lib].append(str(path))
             else:
@@ -213,7 +221,7 @@ def push(
 @opt_pdk_root
 @opt_push
 @click.argument("version")
-def push_cmd(owner, repository, token, pre, pdk_root, pdk, version):
+def push_cmd(owner, repository, token, pre, pdk_root, pdk, version, push_libraries):
     """
     For maintainers: Package and release a build to the public.
 
@@ -221,4 +229,4 @@ def push_cmd(owner, repository, token, pre, pdk_root, pdk, version):
 
     Parameters: <version> (required)
     """
-    push(pdk_root, pdk, version, owner, repository, token, pre)
+    push(pdk_root, pdk, version, owner, repository, token, pre, push_libraries)

--- a/volare/build/asap7.py
+++ b/volare/build/asap7.py
@@ -62,7 +62,7 @@ def get_orfs(version, build_directory, jobs=1):
     except subprocess.CalledProcessError as e:
         print(e)
         print(e.stderr)
-        exit(os.EX_DATAERR)
+        exit(-1)
 
 
 def build_variants(build_directory, jobs):

--- a/volare/build/gf180mcu.py
+++ b/volare/build/gf180mcu.py
@@ -27,7 +27,6 @@ from rich.progress import Progress
 from .magic import with_magic
 from .git_multi_clone import GitMultiClone
 from ..common import (
-    get_logs_dir,
     get_version_dir,
     get_volare_dir,
     mkdirp,
@@ -113,7 +112,7 @@ def get_open_pdks(
     except subprocess.CalledProcessError as e:
         print(e)
         print(e.stderr)
-        exit(os.EX_DATAERR)
+        exit(-1)
 
 
 LIB_FLAG_MAP = {
@@ -194,7 +193,7 @@ def build_variants(
     except subprocess.CalledProcessError as e:
         print(e)
         print(e.stderr)
-        exit(os.EX_DATAERR)
+        exit(-1)
 
 
 def install_gf180mcu(build_directory, pdk_root, version):
@@ -240,21 +239,21 @@ def build(
     if include_libraries is None:
         include_libraries = Family.by_name["gf180mcu"].default_includes.copy()
     if "all" in include_libraries:
-        include_libraries = list(LIB_FLAG_MAP.keys())
+        include_libraries = Family.by_name["gf180mcu"].all_libraries.copy()
 
     if using_repos is None:
         using_repos = {}
 
     timestamp = datetime.now().strftime("build_gf180mcu-%Y-%m-%d-%H-%M-%S")
-    log_dir = os.path.join(get_logs_dir(), timestamp)
+    build_directory = os.path.join(
+        get_volare_dir(pdk_root, "gf180mcu"), "build", version
+    )
+    log_dir = os.path.join(build_directory, "logs", timestamp)
     mkdirp(log_dir)
 
     console = Console()
     console.log(f"Logging to '{log_dir}'…")
 
-    build_directory = os.path.join(
-        get_volare_dir(pdk_root, "gf180mcu"), "build", version
-    )
     open_pdks_path, _, magic_tag = get_open_pdks(
         version, build_directory, jobs, using_repos.get("open_pdks")
     )

--- a/volare/click_common.py
+++ b/volare/click_common.py
@@ -93,9 +93,18 @@ def opt_push(function: Callable):
         "-t",
         "--token",
         default=os.getenv("GITHUB_TOKEN"),
+        required=os.getenv("GITHUB_TOKEN") is None,
         help="Github Token",
     )(function)
     function = opt(
         "--pre/--prod", default=False, help="Push as pre-release or production"
+    )(function)
+    function = opt(
+        "-L",
+        "--push-library",
+        "push_libraries",
+        multiple=True,
+        default=None,
+        help="Push only libraries in this list. You can use -L multiple times to include multiple libraries. Pass 'None' to push all libraries built.",
     )(function)
     return function

--- a/volare/common.py
+++ b/volare/common.py
@@ -234,7 +234,7 @@ def check_version(
                 pr(
                     "Any of ./tool_metadata.yml or ./dependencies/tool_metadata.yml not found. You'll need to specify the file path or the commits explicitly."
                 )
-                exit(os.EX_USAGE)
+                exit(-1)
 
     tool_metadata = yaml.safe_load(open(tool_metadata_file_path).read())
 
@@ -242,7 +242,7 @@ def check_version(
 
     if len(open_pdks_list) < 1:
         pr("No entry for open_pdks found in tool_metadata.yml")
-        exit(os.EX_USAGE)
+        exit(-1)
 
     version = open_pdks_list[0]["commit"]
 
@@ -309,13 +309,6 @@ def get_release_links(
     raise Exception(
         f"The release for {pdk}-{version} is malformed. Please file a bug report."
     )
-
-
-def get_logs_dir() -> str:
-    if os.getenv("VOLARE_LOGS") is not None:
-        return os.environ["VOLARE_LOGS"]
-    else:
-        return os.path.join(VOLARE_RESOLVED_HOME, "volare", "logs")
 
 
 def get_date_of(opdks_commit: str) -> Optional[datetime]:

--- a/volare/families.py
+++ b/volare/families.py
@@ -17,10 +17,17 @@ from typing import List, Dict
 class Family(object):
     by_name: Dict[str, "Family"] = {}
 
-    def __init__(self, name: str, variants: List[str], default_includes: List[str]):
+    def __init__(
+        self,
+        name: str,
+        variants: List[str],
+        default_includes: List[str],
+        all_libraries: List[str],
+    ):
         self.name = name
         self.variants = variants
         self.default_includes = default_includes
+        self.all_libraries = all_libraries
 
 
 Family.by_name = {}
@@ -30,9 +37,24 @@ Family.by_name["sky130"] = Family(
     [
         "sky130_fd_io",
         "sky130_fd_pr",
+        "sky130_fd_pr_reram",
         "sky130_fd_sc_hd",
         "sky130_fd_sc_hvl",
         "sky130_ml_xx_hd",
+        "sky130_sram_macros",
+    ],
+    [
+        "sky130_fd_io",
+        "sky130_fd_pr",
+        "sky130_fd_pr_reram",
+        "sky130_ml_xx_hd",
+        "sky130_fd_sc_hd",
+        "sky130_fd_sc_hdll",
+        "sky130_fd_sc_lp",
+        "sky130_fd_sc_hvl",
+        "sky130_fd_sc_ls",
+        "sky130_fd_sc_ms",
+        "sky130_fd_sc_hs",
         "sky130_sram_macros",
     ],
 )
@@ -46,5 +68,16 @@ Family.by_name["gf180mcu"] = Family(
         "gf180mcu_fd_sc_mcu9t5v0",
         "gf180mcu_fd_ip_sram",
     ],
+    [
+        "gf180mcu_fd_io",
+        "gf180mcu_fd_pr",
+        "gf180mcu_fd_sc_mcu7t5v0",
+        "gf180mcu_fd_sc_mcu9t5v0",
+        "gf180mcu_fd_ip_sram",
+        "gf180mcu_osu_sc_gp12t3v3",
+        "gf180mcu_osu_sc_gp9t3v3",
+    ],
 )
-Family.by_name["asap7"] = Family("asap7", ["asap7"], default_includes=[])
+Family.by_name["asap7"] = Family(
+    "asap7", ["asap7"], default_includes=[], all_libraries=[]
+)

--- a/volare/manage.py
+++ b/volare/manage.py
@@ -11,17 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import io
 import os
-import sys
-import json
 import shutil
 import tarfile
 import requests
 import tempfile
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 import rich
-import click
 import rich.tree
 import rich.progress
 import zstandard as zstd
@@ -30,20 +28,17 @@ from rich.console import Console
 from .build.git_multi_clone import mkdirp
 from .common import (
     Version,
-    check_version,
     get_release_links,
     get_versions_dir,
     get_volare_dir,
     get_installed_list,
 )
-from .click_common import (
-    opt,
-    opt_build,
-    opt_push,
-    opt_pdk_root,
-)
 from .build import build, push
 from .families import Family
+
+
+class VersionNotFound(Exception):
+    pass
 
 
 def print_installed_list(
@@ -110,128 +105,6 @@ def print_remote_list(
     console.print(tree)
 
 
-# -- CLI
-@click.command("output")
-@opt_pdk_root
-def output_cmd(pdk_root, pdk):
-    """Outputs the currently enabled PDK version.
-
-    If not outputting to a tty, the output is either the version string
-    unembellished, or, if no current version is enabled, an empty output with an
-    exit code of 1.
-    """
-
-    version = Version.get_current(pdk_root, pdk)
-    if sys.stdout.isatty():
-        if version is None:
-            print(f"No version of the PDK {pdk} is currently enabled at {pdk_root}.")
-            print(
-                "Invoke volare --help for assistance installing and enabling versions."
-            )
-            exit(1)
-        else:
-            print(f"Installed: {pdk} v{version.name}")
-            print(
-                "Invoke volare --help for assistance installing and enabling versions."
-            )
-    else:
-        if version is None:
-            exit(1)
-        else:
-            print(version.name, end="")
-
-
-@click.command("prune")
-@opt_pdk_root
-@click.option(
-    "--yes",
-    is_flag=True,
-    callback=lambda c, _, v: not v and c.abort(),
-    expose_value=False,
-    prompt="Are you sure? This will delete all non-enabled versions of the PDK from your computer.",
-)
-def prune_cmd(pdk_root, pdk):
-    """Removes all PDKs other than, if it exists, the one currently in use."""
-    pdk_versions = get_installed_list(pdk_root, pdk)
-    for version in pdk_versions:
-        if version.is_current(pdk_root):
-            continue
-        try:
-            version.uninstall()
-            print(f"Deleted {version}.")
-        except Exception as e:
-            print(f"Failed to delete {version}: {e}", file=sys.stderr)
-
-
-@click.command("rm")
-@opt_pdk_root
-@click.option(
-    "--yes",
-    is_flag=True,
-    callback=lambda c, _, v: not v and c.abort(),
-    expose_value=False,
-    prompt="Are you sure? This will delete this version of the PDK from your computer.",
-)
-@click.argument("version", required=False)
-def rm_cmd(pdk_root, pdk, version):
-    """Removes the PDK version specified."""
-    version_object = Version(version, pdk)
-    try:
-        version_object.uninstall(pdk_root)
-        print(f"Deleted {version}.")
-    except Exception as e:
-        print(f"Failed to delete: {e}", file=sys.stderr)
-        exit(1)
-
-
-@click.command("ls")
-@opt_pdk_root
-def list_cmd(pdk_root, pdk):
-    """Lists PDK versions that are locally installed. JSON if not outputting to a tty."""
-
-    pdk_versions = get_installed_list(pdk_root, pdk)
-
-    if sys.stdout.isatty():
-        console = Console()
-        print_installed_list(pdk_root, pdk, console, pdk_versions)
-    else:
-        print(json.dumps([version.name for version in pdk_versions]), end="")
-
-
-@click.command("ls-remote")
-@opt_pdk_root
-def list_remote_cmd(pdk_root, pdk):
-    """Lists PDK versions that are remotely available. JSON if not outputting to a tty."""
-
-    try:
-        all_versions = Version._from_github()
-        pdk_versions = all_versions.get(pdk) or []
-
-        if sys.stdout.isatty():
-            console = Console()
-            print_remote_list(pdk_root, pdk, console, pdk_versions)
-        else:
-            print(json.dumps([version.name for version in pdk_versions]), end="")
-    except requests.exceptions.ConnectionError:
-        if sys.stdout.isatty():
-            console = Console()
-            console.print(
-                "[red]You don't appear to be connected to the Internet. ls-remote cannot be used."
-            )
-        else:
-            print("Failed to connect to remote server", file=sys.stderr)
-        sys.exit(-1)
-
-
-@click.command("path")
-@opt_pdk_root
-@click.argument("version", required=False)
-def path_cmd(pdk_root, pdk, version):
-    """Prints the path of a specific pdk version installation."""
-    version = Version(version, pdk)
-    print(version.get_dir(pdk_root), end="")
-
-
 def enable(
     pdk_root: str,
     pdk: str,
@@ -241,9 +114,11 @@ def enable(
     build_kwargs: dict = {},
     push_kwargs: dict = {},
     include_libraries: Optional[List[str]] = None,
+    output: Union[Console, io.TextIOWrapper] = Console(),
 ):
-    console = Console()
-
+    console = output
+    if not isinstance(console, Console):
+        console = Console(file=console)
     current_file = os.path.join(get_volare_dir(pdk_root, pdk), "current")
     current_file_dir = os.path.dirname(current_file)
     mkdirp(current_file_dir)
@@ -254,8 +129,7 @@ def enable(
 
     pdk_family = Family.by_name.get(pdk)
     if pdk_family is None:
-        print(f"Unsupported PDK family '{pdk}'.", file=sys.stderr)
-        exit(os.EX_USAGE)
+        raise ValueError(f"Unsupported PDK family '{pdk}'.")
 
     variants = pdk_family.variants
 
@@ -272,10 +146,9 @@ def enable(
                 if also_push:
                     push(pdk_root=pdk_root, pdk=pdk, version=version, **push_kwargs)
             else:
-                console.print(
-                    f"[red]Version {version} not found either locally or remotely.\nTry volare build {version}."
+                raise FileNotFoundError(
+                    f"Version {version} not found either locally or remotely."
                 )
-                exit(1)
         else:
             try:
                 tarball_directory = tempfile.TemporaryDirectory(suffix=".volare")
@@ -315,19 +188,18 @@ def enable(
                                 mkdirp(final_dir)
                                 io = tf.extractfile(file)
                                 if io is None:
-                                    raise ValueError(
-                                        f"Failed to unpack tarball for {name}."
+                                    raise IOError(
+                                        f"Failed to unpack file in {name}'s tarball: {file.name}."
                                     )
                                 with open(final_path, "wb") as f:
                                     f.write(io.read())
-            except Exception as e:
-                shutil.rmtree(version_directory, ignore_errors=True)
-                console.print(f"[red]Error: {e}")
-                exit(-1)
-            except KeyboardInterrupt:
+            except KeyboardInterrupt as e:
                 console.print("Interrupted.")
                 shutil.rmtree(version_directory, ignore_errors=True)
-                exit(-1)
+                raise e from None
+            except Exception as e:
+                shutil.rmtree(version_directory, ignore_errors=True)
+                raise e from None
 
             for variant in variants:
                 variant_install_path = os.path.join(version_directory, variant)
@@ -344,10 +216,9 @@ def enable(
                 if os.path.islink(path):
                     os.unlink(path)
                 else:
-                    console.print(
-                        f"[red]Error: {path} exists, and not as a symlink. Please manually remove it before continuing."
+                    raise FileExistsError(
+                        f"{path} exists, and not as a symlink. Remove it first."
                     )
-                    exit(1)
 
         for vpath, fpath in zip(version_paths, final_paths):
             src = os.path.relpath(vpath, pdk_root)
@@ -357,106 +228,3 @@ def enable(
             f.write(version)
 
     console.print(f"Version {version} enabled for the {pdk} PDK.")
-
-
-@click.command("enable")
-@opt_pdk_root
-@click.option(
-    "-f",
-    "--metadata-file",
-    "tool_metadata_file_path",
-    default=None,
-    help="Explicitly define a tool metadata file instead of searching for a metadata file",
-)
-@click.option(
-    "-l",
-    "--include-libraries",
-    multiple=True,
-    default=None,
-    help="Libraries to include. You can use -l multiple times to include multiple libraries. Pass 'all' to include all of them. A default of 'None' uses a default set for the particular PDK.",
-)
-@click.argument("version", required=False)
-def enable_cmd(pdk_root, pdk, tool_metadata_file_path, version, include_libraries):
-    """
-    Activates a given installed PDK version.
-
-    Parameters: <version> (Optional)
-
-    If a version is not given, and you run this in the top level directory of
-    tools with a tool_metadata.yml file, for example OpenLane or DFFRAM,
-    the appropriate version will be enabled automatically.
-    """
-    if include_libraries == ():
-        include_libraries = None
-
-    console = Console()
-    version = check_version(version, tool_metadata_file_path, console)
-    enable(
-        pdk_root=pdk_root,
-        pdk=pdk,
-        version=version,
-        include_libraries=include_libraries,
-    )
-
-
-@click.command("enable_or_build", hidden=True)
-@opt_pdk_root
-@opt_push
-@opt_build
-@opt("--also-push/--dont-push", default=False, help="Also push.")
-@click.option(
-    "-f",
-    "--metadata-file",
-    "tool_metadata_file_path",
-    default=None,
-    help="Explicitly define a tool metadata file instead of searching for a metadata file",
-)
-@click.argument("version")
-def enable_or_build_cmd(
-    include_libraries,
-    jobs,
-    pdk_root,
-    pdk,
-    owner,
-    repository,
-    token,
-    pre,
-    clear_build_artifacts,
-    tool_metadata_file_path,
-    also_push,
-    version,
-    use_repo_at,
-    build_magic,
-):
-    """
-    Attempts to activate a given PDK version. If the version is not found locally or remotely,
-    it will instead attempt to build said version.
-
-    Parameters: <version>
-    """
-    if include_libraries == ():
-        include_libraries = None
-
-    console = Console()
-    version = check_version(version, tool_metadata_file_path, console)
-    enable(
-        pdk_root=pdk_root,
-        pdk=pdk,
-        version=version,
-        build_if_not_found=True,
-        also_push=also_push,
-        build_kwargs={
-            "include_libraries": include_libraries,
-            "jobs": jobs,
-            "clear_build_artifacts": clear_build_artifacts,
-            "use_repo_at": use_repo_at,
-            "build_magic": build_magic,
-        },
-        push_kwargs={
-            "owner": owner,
-            "repository": repository,
-            "token": token,
-            "pre": pre,
-        },
-        include_libraries=include_libraries,
-    )


### PR DESCRIPTION
+ Add list of full SCLs to PDK families
+ Added ability to specify which SCLs to push
~ Moved management-related CLI functions to `__main__.py`
~ Fixed github token requirement check
~ `manage.py::enable` no longer attempts to exit on its own, raises Exceptions like a responsible citizen
- Removed `os.EX_` exits- not available on Windows