### PR TITLE
Update build procedure for gf180mcu and sky130 according to latest open_pdks

### DIFF
--- a/volare/__version__.py
+++ b/volare/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.9.2"
+__version__ = "0.10.0"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/volare/build/gf180mcu.py
+++ b/volare/build/gf180mcu.py
@@ -151,6 +151,13 @@ def build_variants(
                 raise e
 
         library_flags = set([LIB_FLAG_MAP[library] for library in include_libraries])
+        library_flags_disable = set(
+            [
+                LIB_FLAG_MAP[library].replace("enable", "disable")
+                for library in LIB_FLAG_MAP
+                if library not in include_libraries
+            ]
+        )
         magic_dirname = os.path.dirname(magic_bin)
 
         with console.status("Configuring open_pdks…"):
@@ -158,7 +165,7 @@ def build_variants(
                 f"""
                     set -e
                     export PATH="{magic_dirname}:$PATH"
-                    ./configure --enable-gf180mcu-pdk {' '.join(library_flags)} --with-reference
+                    ./configure --enable-gf180mcu-pdk {' '.join(library_flags)} {' '.join(library_flags_disable)} --with-reference
                 """,
                 log_to=os.path.join(log_dir, "config.log"),
             )
@@ -187,6 +194,15 @@ def build_variants(
                 log_to=os.path.join(log_dir, "ownership.log"),
             )
         console.log("Fixed file ownership.")
+        with console.status("Cleaning build artifacts…"):
+            run_sh(
+                f"""
+                set -e
+                rm -rf sources
+                """,
+                log_to=os.path.join(log_dir, "clean.log"),
+            )
+        console.log("Cleaned build artifacts.")
 
         console.log("Done.")
 

--- a/volare/build/gf180mcu.py
+++ b/volare/build/gf180mcu.py
@@ -196,7 +196,7 @@ def build_variants(
         console.log("Fixed file ownership.")
         with console.status("Cleaning build artifacts…"):
             run_sh(
-                f"""
+                """
                 set -e
                 rm -rf sources
                 """,

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -309,6 +309,7 @@ def build_variants(
                 if library not in include_libraries
             ]
         )
+        console.log(f'Using libraries {" ".join(library_flags)}')
 
         with console.status("Configuring open_pdks…"):
             run_sh(
@@ -346,7 +347,7 @@ def build_variants(
         console.log("Fixed file ownership.")
         with console.status("Cleaning build artifacts…"):
             run_sh(
-                f"""
+                """
                 set -e
                 rm -rf sources
                 """,

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -344,6 +344,15 @@ def build_variants(
                 log_to=os.path.join(log_dir, "ownership.log"),
             )
         console.log("Fixed file ownership.")
+        with console.status("Cleaning build artifacts…"):
+            run_sh(
+                f"""
+                set -e
+                rm -rf sources
+                """,
+                log_to=os.path.join(log_dir, "clean.log"),
+            )
+        console.log("Cleaned build artifacts.")
 
         console.log("Done.")
 

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -94,18 +94,17 @@ def get_open_pdks(
             manifest = json.loads(json_str)
             reference_commits = manifest["reference"]
             magic_tag = reference_commits["magic"]
-            sky130_tag = reference_commits["skywater_pdk"]
         except FileNotFoundError:
             console.log(
-                "Cannot find open_pdks/sky130 JSON manifest. Default versions for sky130/magic will be used."
+                "Cannot find open_pdks/sky130 JSON manifest. Default versions for magic will be used."
             )
         except json.JSONDecodeError:
             console.log(
-                "Failed to parse open_pdks/sky130 JSON manifest. Default versions for sky130/magic will be used."
+                "Failed to parse open_pdks/sky130 JSON manifest. Default versions for magic will be used."
             )
         except KeyError:
             console.log(
-                "Failed to extract reference commits from open_pdks/sky130 JSON manifest. Default versions for sky130/magic will be used."
+                "Failed to extract reference commits from open_pdks/sky130 JSON manifest. Default versions for magic will be used."
             )
 
         return (repo_path, sky130_tag, magic_tag)
@@ -254,12 +253,27 @@ def build_sky130_timing(build_directory, sky130_path, log_dir, jobs=1):
         exit(-1)
 
 
+LIB_FLAG_MAP = {
+    "sky130_fd_io": "--enable-io-sky130",
+    "sky130_fd_pr": "--enable-primitive-sky130",
+    "sky130_fd_pr_reram": "",
+    "sky130_ml_xx_hd": "--enable-alpha-sky130",
+    "sky130_fd_sc_hd": "--enable-sc-hd-sky130",
+    "sky130_fd_sc_hdll": "--enable-sc-hdll-sky130",
+    "sky130_fd_sc_lp": "--enable-sc-lp-sky130",
+    "sky130_fd_sc_hvl": "--enable-sc-hvl-sky130",
+    "sky130_fd_sc_ls": "--enable-sc-ls-sky130",
+    "sky130_fd_sc_ms": "--enable-sc-ms-sky130",
+    "sky130_fd_sc_hs": "--enable-sc-hs-sky130",
+    "sky130_sram_macros": "--enable-sram-sky130",
+}
+
+
 def build_variants(
     magic_bin,
-    sram,
     build_directory,
     open_pdks_path,
-    sky130_path,
+    include_libraries,
     log_dir,
     jobs=1,
 ):
@@ -286,15 +300,22 @@ def build_variants(
                 )
                 raise e
 
-        sram_opt = "--enable-sram-sky130" if sram else ""
         magic_dirname = os.path.dirname(magic_bin)
+        library_flags = set([LIB_FLAG_MAP[library] for library in include_libraries])
+        library_flags_disable = set(
+            [
+                LIB_FLAG_MAP[library].replace("enable", "disable")
+                for library in LIB_FLAG_MAP
+                if library not in include_libraries
+            ]
+        )
 
         with console.status("Configuring open_pdks…"):
             run_sh(
                 f"""
                     set -e
                     export PATH="{magic_dirname}:$PATH"
-                    ./configure --enable-sky130-pdk={sky130_path}/libraries {sram_opt} --with-reference
+                    ./configure --enable-sky130-pdk {" ".join(library_flags)} {" ".join(library_flags_disable)} --with-reference
                 """,
                 log_to=os.path.join(log_dir, "config.log"),
             )
@@ -388,13 +409,9 @@ def build(
     console = Console()
     console.log(f"Logging to '{log_dir}'…")
 
-    open_pdks_path, sky130_tag, magic_tag = get_open_pdks(
+    open_pdks_path, _, magic_tag = get_open_pdks(
         version, build_directory, jobs, using_repos.get("open_pdks")
     )
-    sky130_path = get_sky130(
-        include_libraries, build_directory, sky130_tag, jobs, using_repos.get("sky130")
-    )
-    build_sky130_timing(build_directory, sky130_path, log_dir, jobs)
 
     # magic_tag = ""
     # open_pdks_path = os.path.join(build_directory, "open_pdks")
@@ -404,10 +421,9 @@ def build(
         magic_tag,
         lambda magic_bin: build_variants(
             magic_bin,
-            "sky130_sram_macros" in include_libraries,
             build_directory,
             open_pdks_path,
-            sky130_path,
+            include_libraries,
             log_dir,
             jobs,
         ),

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -96,15 +96,15 @@ def get_open_pdks(
             magic_tag = reference_commits["magic"]
         except FileNotFoundError:
             console.log(
-                "Cannot find open_pdks/sky130 JSON manifest. Default versions for magic will be used."
+                "Cannot find open_pdks/sky130 JSON manifest. Default version for magic will be used."
             )
         except json.JSONDecodeError:
             console.log(
-                "Failed to parse open_pdks/sky130 JSON manifest. Default versions for magic will be used."
+                "Failed to parse open_pdks/sky130 JSON manifest. Default version for magic will be used."
             )
         except KeyError:
             console.log(
-                "Failed to extract reference commits from open_pdks/sky130 JSON manifest. Default versions for magic will be used."
+                "Failed to extract reference commits from open_pdks/sky130 JSON manifest. Default version for magic will be used."
             )
 
         return (repo_path, sky130_tag, magic_tag)


### PR DESCRIPTION

common:
```
+ generate --disable<scl/lib> similar to --enable since almost everything is enabled by default now
```

sky130:
```
+ add LIB_FLAG_MAP similar to gf180mcu
~ treat sram as a any other lib now
- remove `sources` folder from open_pdks to save space if build finishes successfully
- remove cloning skywater-pdk
```

> \* This could be wrapped as an option although I don't see a reason for keeping sources folder after the build is successful. 