### PR TITLE
Fix `setup.py` version extraction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,30 @@
 #!/usr/bin/env python3
+import os
+import subprocess
 from setuptools import setup, find_packages
 
-from volare import __version__
+module_name = "volare"
+
+__dir__ = os.path.dirname(__file__)
+version = subprocess.check_output(
+    [
+        "python3",
+        os.path.join(
+            os.path.abspath(__dir__),
+            module_name,
+            "__version__.py",
+        ),
+    ],
+    encoding="utf8",
+)
 
 requirements = open("requirements.txt").read().strip().split("\n")
 
 setup(
-    name="volare",
+    name=module_name,
     packages=find_packages(),
     package_data={"volare": ["py.typed"]},
-    version=__version__,
+    version=version,
     description="An open_pdks PDK builder/version manager",
     long_description=open("Readme.md").read(),
     long_description_content_type="text/markdown",

--- a/volare/__version__.py
+++ b/volare/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 
 if __name__ == "__main__":
     print(__version__, end="")


### PR DESCRIPTION
`setup.py` used to import the module to get the version number, which would require all dependencies to already be successfully installed. This makes it match OpenLane 2 where the version is obtained without importing the module at all.