### PR TITLE
API Cleanup

### DIFF
--- a/volare/__main__.py
+++ b/volare/__main__.py
@@ -28,6 +28,7 @@ from .click_common import (
     opt_build,
     opt_push,
     opt_pdk_root,
+    opt_token,
 )
 from .manage import (
     print_installed_list,
@@ -41,6 +42,7 @@ from .build import (
 
 
 @click.command("output")
+@opt_token
 @opt_pdk_root
 def output_cmd(pdk_root, pdk):
     """Outputs the currently enabled PDK version.
@@ -71,6 +73,7 @@ def output_cmd(pdk_root, pdk):
 
 
 @click.command("prune")
+@opt_token
 @opt_pdk_root
 @click.option(
     "--yes",
@@ -93,6 +96,7 @@ def prune_cmd(pdk_root, pdk):
 
 
 @click.command("rm")
+@opt_token
 @opt_pdk_root
 @click.option(
     "--yes",
@@ -114,6 +118,7 @@ def rm_cmd(pdk_root, pdk, version):
 
 
 @click.command("ls")
+@opt_token
 @opt_pdk_root
 def list_cmd(pdk_root, pdk):
     """Lists PDK versions that are locally installed. JSON if not outputting to a tty."""
@@ -128,6 +133,7 @@ def list_cmd(pdk_root, pdk):
 
 
 @click.command("ls-remote")
+@opt_token
 @opt_pdk_root
 def list_remote_cmd(pdk_root, pdk):
     """Lists PDK versions that are remotely available. JSON if not outputting to a tty."""
@@ -141,6 +147,13 @@ def list_remote_cmd(pdk_root, pdk):
             print_remote_list(pdk_root, pdk, console, pdk_versions)
         else:
             print(json.dumps([version.name for version in pdk_versions]), end="")
+    except requests.exceptions.HTTPError as e:
+        if sys.stdout.isatty():
+            console = Console()
+            console.print(f"[red]Encountered an error when polling version list: {e}")
+        else:
+            print(f"Failed to get version list: {e}", file=sys.stderr)
+        sys.exit(-1)
     except requests.exceptions.ConnectionError:
         if sys.stdout.isatty():
             console = Console()
@@ -153,6 +166,7 @@ def list_remote_cmd(pdk_root, pdk):
 
 
 @click.command("path")
+@opt_token
 @opt_pdk_root
 @click.argument("version", required=False)
 def path_cmd(pdk_root, pdk, version):
@@ -162,6 +176,7 @@ def path_cmd(pdk_root, pdk, version):
 
 
 @click.command("enable")
+@opt_token
 @opt_pdk_root
 @click.option(
     "-f",
@@ -212,6 +227,7 @@ def enable_cmd(pdk_root, pdk, tool_metadata_file_path, version, include_librarie
 
 
 @click.command("enable_or_build", hidden=True)
+@opt_token
 @opt_pdk_root
 @opt_push
 @opt_build
@@ -231,7 +247,6 @@ def enable_or_build_cmd(
     pdk,
     owner,
     repository,
-    token,
     pre,
     clear_build_artifacts,
     tool_metadata_file_path,
@@ -275,7 +290,6 @@ def enable_or_build_cmd(
             push_kwargs={
                 "owner": owner,
                 "repository": repository,
-                "token": token,
                 "pre": pre,
                 "push_libraries": push_libraries,
             },

--- a/volare/__main__.py
+++ b/volare/__main__.py
@@ -21,8 +21,7 @@ from rich.console import Console
 from .__version__ import __version__
 from .common import (
     Version,
-    check_version,
-    get_installed_list,
+    resolve_version,
 )
 from .click_common import (
     opt,
@@ -82,7 +81,7 @@ def output_cmd(pdk_root, pdk):
 )
 def prune_cmd(pdk_root, pdk):
     """Removes all PDKs other than, if it exists, the one currently in use."""
-    pdk_versions = get_installed_list(pdk_root, pdk)
+    pdk_versions = Version.get_all_installed(pdk_root, pdk)
     for version in pdk_versions:
         if version.is_current(pdk_root):
             continue
@@ -119,7 +118,7 @@ def rm_cmd(pdk_root, pdk, version):
 def list_cmd(pdk_root, pdk):
     """Lists PDK versions that are locally installed. JSON if not outputting to a tty."""
 
-    pdk_versions = get_installed_list(pdk_root, pdk)
+    pdk_versions = Version.get_all_installed(pdk_root, pdk)
 
     if sys.stdout.isatty():
         console = Console()
@@ -193,7 +192,12 @@ def enable_cmd(pdk_root, pdk, tool_metadata_file_path, version, include_librarie
         include_libraries = None
 
     console = Console()
-    version = check_version(version, tool_metadata_file_path, console)
+    try:
+        version = resolve_version(version, tool_metadata_file_path)
+    except Exception as e:
+        console.print(f"Could not determine open_pdks version: {e}")
+        exit(-1)
+
     try:
         enable(
             pdk_root=pdk_root,
@@ -249,7 +253,11 @@ def enable_or_build_cmd(
         push_libraries = include_libraries
 
     console = Console()
-    version = check_version(version, tool_metadata_file_path, console)
+    try:
+        version = resolve_version(version, tool_metadata_file_path)
+    except Exception as e:
+        console.print(f"Could not determine open_pdks version: {e}")
+        exit(-1)
     try:
         enable(
             pdk_root=pdk_root,

--- a/volare/__version__.py
+++ b/volare/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.11.3"
+__version__ = "0.12.0"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/volare/build/__init__.py
+++ b/volare/build/__init__.py
@@ -29,6 +29,7 @@ from ..github import (
     get_open_pdks_commit_date,
     VOLARE_REPO_NAME,
     VOLARE_REPO_OWNER,
+    credentials,
 )
 from ..common import (
     mkdirp,
@@ -40,6 +41,7 @@ from ..click_common import (
     opt_push,
     opt_build,
     opt_pdk_root,
+    opt_token,
 )
 from ..families import Family
 
@@ -80,6 +82,7 @@ def build(
 
 
 @click.command("build")
+@opt_token
 @opt_pdk_root
 @opt_build
 @click.option(
@@ -138,10 +141,12 @@ def push(
     version,
     owner=VOLARE_REPO_OWNER,
     repository=VOLARE_REPO_NAME,
-    token=os.getenv("GITHUB_TOKEN"),
     pre=False,
     push_libraries=None,
 ):
+    if credentials.token is None:
+        raise TypeError("Attempted to push without set token")
+
     console = Console()
 
     if push_libraries is None:
@@ -209,7 +214,7 @@ def push(
                 "-repository",
                 repository,
                 "-token",
-                token,
+                credentials.token,
                 "-body",
                 body,
                 "-commitish",
@@ -226,10 +231,11 @@ def push(
 
 
 @click.command("push", hidden=True)
+@opt_token
 @opt_pdk_root
 @opt_push
 @click.argument("version")
-def push_cmd(owner, repository, token, pre, pdk_root, pdk, version, push_libraries):
+def push_cmd(owner, repository, pre, pdk_root, pdk, version, push_libraries):
     """
     For maintainers: Package and release a build to the public.
 
@@ -237,4 +243,4 @@ def push_cmd(owner, repository, token, pre, pdk_root, pdk, version, push_librari
 
     Parameters: <version> (required)
     """
-    push(pdk_root, pdk, version, owner, repository, token, pre, push_libraries)
+    push(pdk_root, pdk, version, owner, repository, pre, push_libraries)

--- a/volare/build/asap7.py
+++ b/volare/build/asap7.py
@@ -20,9 +20,9 @@ from concurrent.futures import ThreadPoolExecutor
 from rich.console import Console
 from rich.progress import Progress
 
+from .common import RepoMetadata
 from .git_multi_clone import GitMultiClone
 from ..common import (
-    RepoMetadata,
     get_version_dir,
     get_volare_dir,
     mkdirp,

--- a/volare/build/common.py
+++ b/volare/build/common.py
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .manage import VersionNotFound, enable, get, root_for
-from .common import get_volare_home, get_current_version, get_installed_list, Version
-from .build import build
 
-from .__version__ import __version__
+
+class RepoMetadata(object):
+    def __init__(self, repo, default_commit, default_branch="main"):
+        self.repo = repo
+        self.default_commit = default_commit
+        self.default_branch = default_branch

--- a/volare/build/gf180mcu.py
+++ b/volare/build/gf180mcu.py
@@ -25,12 +25,12 @@ from rich.console import Console
 from rich.progress import Progress
 
 from .magic import with_magic
+from .common import RepoMetadata
 from .git_multi_clone import GitMultiClone
 from ..common import (
     get_version_dir,
     get_volare_dir,
     mkdirp,
-    RepoMetadata,
     OPDKS_REPO_HTTPS,
 )
 from ..families import Family

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -25,13 +25,13 @@ import pcpp
 from rich.console import Console
 from rich.progress import Progress
 
-from .git_multi_clone import GitMultiClone
 from .magic import with_magic
+from .common import RepoMetadata
+from .git_multi_clone import GitMultiClone
 from ..common import (
     get_version_dir,
     get_volare_dir,
     mkdirp,
-    RepoMetadata,
     OPDKS_REPO_HTTPS,
 )
 from ..families import Family

--- a/volare/click_common.py
+++ b/volare/click_common.py
@@ -17,7 +17,8 @@ from typing import Callable
 
 import click
 
-from .common import VOLARE_RESOLVED_HOME, VOLARE_REPO_OWNER, VOLARE_REPO_NAME
+from .common import VOLARE_RESOLVED_HOME
+from .github import VOLARE_REPO_OWNER, VOLARE_REPO_NAME
 
 opt = partial(click.option, show_default=True)
 
@@ -89,12 +90,12 @@ def opt_push(function: Callable):
     function = opt("-r", "--repository", default=VOLARE_REPO_NAME, help="Repository")(
         function
     )
-    function = opt(
+    function = click.option(
         "-t",
         "--token",
         default=os.getenv("GITHUB_TOKEN"),
         required=os.getenv("GITHUB_TOKEN") is None,
-        help="Github Token",
+        help="Github Token to upload with. If it is not needed, just pass -t NULL or similar. If it exists, the value of the environment variable GITHUB_TOKEN will be used by default.",
     )(function)
     function = opt(
         "--pre/--prod", default=False, help="Push as pre-release or production"

--- a/volare/github.py
+++ b/volare/github.py
@@ -1,0 +1,78 @@
+# Copyright 2022-2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass
+import os
+import json
+import requests
+from datetime import datetime
+from typing import Any, List, Mapping, Optional
+
+
+VOLARE_REPO_OWNER = os.getenv("VOLARE_REPO_OWNER") or "efabless"
+VOLARE_REPO_NAME = os.getenv("VOLARE_REPO_NAME") or "volare"
+VOLARE_REPO_ID = f"{VOLARE_REPO_OWNER}/{VOLARE_REPO_NAME}"
+VOLARE_REPO_HTTPS = f"https://github.com/{VOLARE_REPO_ID}"
+VOLARE_REPO_API = f"https://api.github.com/repos/{VOLARE_REPO_ID}"
+
+
+OPDKS_REPO_OWNER = os.getenv("OPDKS_REPO_OWNER") or "RTimothyEdwards"
+OPDKS_REPO_NAME = os.getenv("OPDKS_REPO_NAME") or "open_pdks"
+OPDKS_REPO_ID = f"{OPDKS_REPO_OWNER}/{OPDKS_REPO_NAME}"
+OPDKS_REPO_HTTPS = f"https://github.com/{OPDKS_REPO_ID}"
+OPDKS_REPO_API = f"https://api.github.com/repos/{OPDKS_REPO_ID}"
+
+
+@dataclass
+class GitHubCredentials:
+    username: Optional[str] = os.getenv("VOLARE_GH_USERNAME") or None
+    token: Optional[str] = (
+        os.getenv("VOLARE_GH_TOKEN") or os.getenv("GITHUB_TOKEN") or None
+    )
+
+    def get_session(self) -> requests.Session:
+        session = requests.Session()
+        if None not in [self.username, self.token]:
+            session.auth = (self.username, self.token)
+        return session
+
+
+def get_open_pdks_commit_date(commit: str) -> Optional[datetime]:
+    try:
+        request = requests.get(f"{OPDKS_REPO_API}/commits/{commit}")
+        request.raise_for_status()
+    except requests.exceptions.ConnectionError:
+        return None
+    except requests.exceptions.HTTPError:
+        return None
+
+    response_str = request.content.decode("utf8")
+    response = json.loads(response_str)
+    date = response["commit"]["author"]["date"]
+    commit_date = datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ")
+    return commit_date
+
+
+def get_releases() -> List[Mapping[str, Any]]:
+    req = requests.get(f"{VOLARE_REPO_API}/releases", params={"per_page": 100})
+    req.raise_for_status()
+
+    return req.json()
+
+
+def get_release_links(release: str) -> Mapping[str, Any]:
+    release_api_link = f"{VOLARE_REPO_API}/releases/tags/{release}"
+    req = requests.get(release_api_link, json=True)
+    req.raise_for_status()
+
+    return req.json()


### PR DESCRIPTION
* Rework API to use the `Version` object more
   * Deprecated: `get_current_version`, `get_version_dir`, `get_installed_list` and `root_for`, all with replacement methods in `Version`
* Functions that request from GitHub moved to their own file, with a credentials object that creates authenticated sessions
* Tokens now follow the following priority:
   * Value of `-t` flag (now available in all commands) if not None
   * Value of GITHUB_TOKEN if not None
   * Extracted from `~/.config/gh/hosts.yml` (if available)