### PR TITLE
Better Variant Change Handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     package_data={"volare": ["py.typed"]},
     version=version,
     description="An open_pdks PDK builder/version manager",
-    long_description=open("Readme.md").read(),
+    long_description=open(os.path.join(__dir__, "Readme.md")).read(),
     long_description_content_type="text/markdown",
     author="Efabless Corporation",
     author_email="donn@efabless.com",

--- a/volare/__version__.py
+++ b/volare/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.12.7"
+__version__ = "0.12.8"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/volare/build/asap7.py
+++ b/volare/build/asap7.py
@@ -131,7 +131,8 @@ def install_asap7(build_directory, pdk_root, version):
         for variant in asap7_family.variants:
             variant_build_path = os.path.join(build_directory, variant)
             variant_install_path = os.path.join(version_directory, variant)
-            shutil.copytree(variant_build_path, variant_install_path)
+            if os.path.isdir(variant_build_path):
+                shutil.copytree(variant_build_path, variant_install_path)
 
     console.log("Done.")
 

--- a/volare/build/gf180mcu.py
+++ b/volare/build/gf180mcu.py
@@ -238,7 +238,8 @@ def install_gf180mcu(build_directory, pdk_root, version):
         for variant in gf180mcu_family.variants:
             variant_build_path = os.path.join(build_directory, variant)
             variant_install_path = os.path.join(version_directory, variant)
-            shutil.copytree(variant_build_path, variant_install_path)
+            if os.path.isdir(variant_build_path):
+                shutil.copytree(variant_build_path, variant_install_path)
 
     console.log("Done.")
 

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -388,7 +388,8 @@ def install_sky130(build_directory, pdk_root, version):
         for variant in sky130_family.variants:
             variant_build_path = os.path.join(build_directory, variant)
             variant_install_path = os.path.join(version_directory, variant)
-            shutil.copytree(variant_build_path, variant_install_path)
+            if os.path.isdir(variant_build_path):
+                shutil.copytree(variant_build_path, variant_install_path)
 
     console.log("Done.")
 

--- a/volare/common.py
+++ b/volare/common.py
@@ -101,7 +101,10 @@ class Version(object):
             return
 
         for variant in Family.by_name[self.pdk].variants:
-            os.unlink(os.path.join(pdk_root, variant))
+            try:
+                os.unlink(os.path.join(pdk_root, variant))
+            except FileNotFoundError:
+                pass
 
         current_file = os.path.join(get_volare_dir(pdk_root, self.pdk), "current")
         os.unlink(current_file)

--- a/volare/manage.py
+++ b/volare/manage.py
@@ -211,6 +211,8 @@ def get(
 
         for variant in variants:
             variant_install_path = os.path.join(version_directory, variant)
+            if not os.path.isdir(variant_install_path):
+                continue
             variant_sources_file = os.path.join(variant_install_path, "SOURCES")
             if not os.path.isfile(variant_sources_file):
                 with open(variant_sources_file, "w") as f:
@@ -271,7 +273,8 @@ def enable(
 
         for vpath, fpath in zip(version_paths, final_paths):
             src = os.path.relpath(vpath, pdk_root)
-            os.symlink(src=src, dst=fpath)
+            if os.path.isdir(vpath):
+                os.symlink(src=src, dst=fpath)
 
         with open(current_file, "w") as f:
             f.write(version)


### PR DESCRIPTION
Variants are no longer presumed to exist in all versions of a PDK, with 0.12.7's adding of `gf180mcuD` having caused issues for older versions.

---
Resolves #69 