### PR TITLE
Add `nil` check guards while attempting to extract auth tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PYTHON3 ?= python3
 REQ_FILES = ./requirements_dev.txt ./requirements.txt
 REQ_FILES_PFX = $(addprefix -r ,$(REQ_FILES))
 
@@ -16,7 +17,7 @@ lint: venv/manifest.txt
 venv: venv/manifest.txt
 venv/manifest.txt: $(REQ_FILES)
 	rm -rf venv
-	python3 -m venv ./venv
+	$(PYTHON3) -m venv ./venv
 	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade pip
 	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade wheel
 	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade $(REQ_FILES_PFX)

--- a/volare/__version__.py
+++ b/volare/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.12.8"
+__version__ = "0.13.0"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/volare/github.py
+++ b/volare/github.py
@@ -43,7 +43,11 @@ def _get_gh_token() -> Optional[str]:
     ghcli_file = os.path.join(os.path.expanduser("~/.config/gh/hosts.yml"))
     if os.path.exists(ghcli_file):
         hosts = yaml.safe_load(open(ghcli_file))
-        token = str(hosts["github.com"]["oauth_token"])
+        gh_host = hosts.get("github.com")
+        if gh_host is not None:
+            oauth_token = gh_host.get("oauth_token")
+            if oauth_token is not None:
+                token = str(oauth_token)
 
     # 1. Higher priority: environment GITHUB_TOKEN
     env_token = os.getenv("GITHUB_TOKEN")

--- a/volare/manage.py
+++ b/volare/manage.py
@@ -177,7 +177,7 @@ def get(
                             with open(final_path, "wb") as f:
                                 f.write(io.read())
         except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 404:
+            if e.response is not None and e.response.status_code == 404:
                 if build_if_not_found:
                     console.print(
                         f"Version {version} not found remotely, attempting to build…"
@@ -192,9 +192,13 @@ def get(
                 else:
                     raise RuntimeError(f"Version {version} not found remotely.")
             else:
-                raise RuntimeError(
-                    f"Failed to obtain {version} remotely: {e.response}."
-                )
+                if e.response is not None:
+                    raise RuntimeError(
+                        f"Failed to obtain {version} remotely: {e.response}."
+                    )
+                else:
+                    raise RuntimeError(f"Failed to request {version} from server: {e}.")
+
         except KeyboardInterrupt as e:
             console.print("Interrupted.")
             shutil.rmtree(version_directory, ignore_errors=True)


### PR DESCRIPTION
Fixes an issue where if you use `ghcli` on platforms where GitHub would simply store its token in the keychain, Volare would not work.