### PR TITLE
Proper "Fetch" Mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click>=8.0.0,<9
 pyyaml>=5,<7
-rich>=13,<14
+rich>=12,<14 # Rich 12 is the last version supporting Python 3.6
 httpx>=0.22.0
 pcpp>=1.2,<2
 zstandard>=0.19.0,<1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click>=8.0.0,<9
 pyyaml>=5,<7
-rich>=12,<13
+rich>=13,<14
 httpx>=0.22.0
 pcpp>=1.2,<2
 zstandard>=0.19.0,<1

--- a/volare/__init__.py
+++ b/volare/__init__.py
@@ -11,8 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .manage import VersionNotFound, enable, get, root_for
-from .common import get_volare_home, get_current_version, get_installed_list, Version
+from .manage import (
+    VersionNotFound,
+    enable,
+    get,
+    fetch,
+)
+from .common import (
+    get_volare_home,
+    get_current_version,
+    get_installed_list,
+    Version,
+    root_for,
+)
+from .github import (
+    GitHubSession,
+)
 from .build import build
 
 from .__version__ import __version__

--- a/volare/__version__.py
+++ b/volare/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.14.1"
+__version__ = "0.15.0"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/volare/build/asap7.py
+++ b/volare/build/asap7.py
@@ -146,6 +146,9 @@ def build(
     using_repos: Optional[Dict[str, str]] = None,
     build_magic: bool = False,
 ):
+    family = Family.by_name["asap7"]
+    _ = family.resolve_libraries(include_libraries)
+
     if using_repos is None:
         using_repos = {}
 

--- a/volare/build/gf180mcu.py
+++ b/volare/build/gf180mcu.py
@@ -129,7 +129,6 @@ LIB_FLAG_MAP = {
 def build_variants(
     magic_bin, include_libraries, build_directory, open_pdks_path, log_dir, jobs=1
 ):
-
     try:
         pdk_root_abs = os.path.abspath(build_directory)
         console = Console()
@@ -253,11 +252,8 @@ def build(
     using_repos: Optional[Dict[str, str]] = None,
     build_magic: bool = False,
 ):
-    if include_libraries is None:
-        include_libraries = Family.by_name["gf180mcu"].default_includes.copy()
-    if "all" in include_libraries:
-        include_libraries = Family.by_name["gf180mcu"].all_libraries.copy()
-    include_libraries = list(include_libraries)
+    family = Family.by_name["gf180mcu"]
+    library_set = family.resolve_libraries(include_libraries)
 
     if using_repos is None:
         using_repos = {}
@@ -280,7 +276,7 @@ def build(
         magic_tag,
         lambda magic_bin: build_variants(
             magic_bin,
-            include_libraries,
+            library_set,
             build_directory,
             open_pdks_path,
             log_dir,

--- a/volare/build/magic.py
+++ b/volare/build/magic.py
@@ -22,7 +22,7 @@ from typing import Callable, Optional, TypeVar
 from rich.console import Console
 
 from ..common import mkdirp
-from ..github import credentials
+from ..github import GitHubSession
 
 T = TypeVar("T")
 
@@ -53,7 +53,7 @@ def with_magic(
 
         console = Console()
         console.status("Downloading Magic repo…")
-        magic_req = credentials.get_session().get(
+        magic_req = GitHubSession().get(
             f"https://github.com/RTimothyEdwards/magic/tarball/{magic_tag}",
         )
         with open(magic_tgz, "wb") as f:

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -402,11 +402,8 @@ def build(
     using_repos: Optional[Dict[str, str]] = None,
     build_magic: bool = False,
 ):
-    if include_libraries is None:
-        include_libraries = Family.by_name["sky130"].default_includes.copy()
-    if "all" in include_libraries:
-        include_libraries = Family.by_name["sky130"].all_libraries.copy()
-    include_libraries = list(include_libraries)
+    family = Family.by_name["sky130"]
+    library_set = family.resolve_libraries(include_libraries)
 
     if using_repos is None:
         using_repos = {}
@@ -433,7 +430,7 @@ def build(
             magic_bin,
             build_directory,
             open_pdks_path,
-            include_libraries,
+            library_set,
             log_dir,
             jobs,
         ),

--- a/volare/click_common.py
+++ b/volare/click_common.py
@@ -18,7 +18,7 @@ from typing import Callable, Optional
 import click
 
 from .common import VOLARE_RESOLVED_HOME
-from .github import VOLARE_REPO_OWNER, VOLARE_REPO_NAME, credentials
+from .github import VOLARE_REPO_OWNER, VOLARE_REPO_NAME, GitHubSession
 
 opt = partial(click.option, show_default=True)
 
@@ -107,17 +107,16 @@ def set_token_cb(
     param: click.Parameter,
     value: Optional[str],
 ):
-    if value is not None:
-        credentials.token = value
+    return GitHubSession(github_token=value)
 
 
 def opt_token(function: Callable) -> Callable:
     function = opt(
         "-t",
         "--token",
+        "session",
         default=None,
         required=False,
-        expose_value=False,
         help="Replace the GitHub token used for GitHub requests, which is by default the value of the environment variable GITHUB_TOKEN or None.",
         callback=set_token_cb,
     )(function)

--- a/volare/common.py
+++ b/volare/common.py
@@ -15,6 +15,7 @@ import os
 import re
 import shutil
 import pathlib
+import warnings
 from datetime import datetime
 from dataclasses import dataclass
 from typing import Iterable, Optional, List, Dict, Tuple, Union
@@ -143,8 +144,11 @@ class Version(object):
         ]
 
     @classmethod
-    def _from_github(Self) -> Dict[str, List["Version"]]:
-        releases = github.get_releases()
+    def _from_github(
+        Self,
+        session: Optional[github.GitHubSession] = None,
+    ) -> Dict[str, List["Version"]]:
+        releases = github.get_releases(session)
 
         rvs_by_pdk: Dict[str, List["Version"]] = {}
 
@@ -181,9 +185,12 @@ class Version(object):
         return rvs_by_pdk
 
     def get_release_links(
-        self, scl_filter: Iterable[str], include_common: bool
+        self,
+        scl_filter: Iterable[str],
+        include_common: bool,
+        session: Optional[github.GitHubSession] = None,
     ) -> List[Tuple[str, str]]:
-        release = github.get_release_links(f"{self.pdk}-{self.name}")
+        release = github.get_release_links(f"{self.pdk}-{self.name}", session)
 
         assets = release["assets"]
         zst_files = []
@@ -258,17 +265,26 @@ def resolve_version(
 
 
 def get_current_version(pdk_root: str, pdk: str) -> Optional[str]:
-    # DEPRECATED: Use `Version.get_current()`
+    warnings.warn("get_current_version() is deprecated, use Version.get_current()")
     return _get_current_version(pdk_root, pdk)
 
 
 def get_installed_list(pdk_root: str, pdk: str) -> list:
-    # DEPRECATED: Use `Version.get_all_installed()`
+    warnings.warn("get_installed_list() is deprecated, use Version.get_all_installed()")
     return Version.get_all_installed(pdk_root, pdk)
 
 
 def get_version_dir(pdk_root: str, pdk: str, version: Union[str, Version]) -> str:
-    # DEPRECATED: Use `Version().get_dir()`
+    warnings.warn("get_version_dir() is deprecated, use Version().get_dir()")
     if not isinstance(version, Version):
         version = Version(version, pdk)
     return version.get_dir(pdk_root)
+
+
+def root_for(
+    pdk_root: str,
+    pdk: str,
+    version: str,
+) -> str:
+    warnings.warn("root_for() has been deprecated: use Version().get_dir()")
+    return Version(version, pdk).get_dir(pdk_root)

--- a/volare/families.py
+++ b/volare/families.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Dict
+from typing import Iterable, List, Dict, Optional, Set
 
 
 class Family(object):
@@ -28,6 +28,25 @@ class Family(object):
         self.variants = variants
         self.default_includes = default_includes
         self.all_libraries = all_libraries
+
+    def resolve_libraries(
+        self,
+        input: Optional[Iterable[str]],
+    ) -> Set[str]:
+        if input is None:
+            input = ("default",)
+        final_set: Set[str] = set()
+        for element in input:
+            if element.lower() == "all":
+                final_set = set(self.all_libraries)
+                return final_set
+            elif element.lower() == "default":
+                final_set = final_set.union(set(self.default_includes))
+            elif element in self.all_libraries:
+                final_set.add(element)
+            else:
+                raise ValueError(f"Unknown library {element} for PDK {self.name}")
+        return final_set
 
 
 Family.by_name = {}


### PR DESCRIPTION
* Created `GitHubSession` based on work from IPM - no longer global, created by `click` in the CLI and passed around to function
* Created new function `fetch()` based on was what previously `get()` (now deprecated), accessible over the CLI using `volare fetch`, which download versions and/or SCLs  without affecting the top-level PDK root
* Changed `get_current_version`, `get_installed_list`, `get_version_dir` and `root_for` to print deprecation warnings
* Consolidated SCL list processing in `Family`-- `Family.resolve_libraries()` takes an iterable list of inputs and returns the set of target SCLs, expanding `default` into the default set and `all` into all SCLs as appropriate
* **API Break**: Most arguments that aren't `pdk_root`, `pdk`, `version` are now keyword-only arguments