### PR TITLE
Resilience to Oddball Internet Setups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ dist: venv/manifest.txt
 
 .PHONY: lint
 lint: venv/manifest.txt
+	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade truststore
 	./venv/bin/black --check .
 	./venv/bin/flake8 .
 	./venv/bin/mypy --check-untyped-defs .

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ dist: venv/manifest.txt
 
 .PHONY: lint
 lint: venv/manifest.txt
-	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade truststore
 	./venv/bin/black --check .
 	./venv/bin/flake8 .
 	./venv/bin/mypy --check-untyped-defs .

--- a/default.nix
+++ b/default.nix
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 {
+  lib,
   buildPythonPackage,
   click,
   pyyaml,
@@ -19,7 +20,8 @@
   httpx,
   pcpp,
   zstandard,
-  nix-gitignore
+  truststore,
+  nix-gitignore,
 }:
 
 buildPythonPackage rec {
@@ -41,5 +43,14 @@ buildPythonPackage rec {
     httpx
     pcpp
     zstandard
-  ];
+    truststore
+  ] ++ httpx.optional-dependencies.socks;
+  
+  meta = with lib; {
+    mainProgram = "volare";
+    description = "Version manager and builder for open-source PDKs";
+    homepage = "https://github.com/efabless/volare";
+    license = licenses.asl20;
+    platforms = platforms.darwin ++ platforms.linux;
+  };
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ rich>=12,<14 # Rich 12 is the last version supporting Python 3.6
 httpx>=0.22.0
 pcpp>=1.2,<2
 zstandard>=0.19.0,<1
-truststore>=0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ rich>=12,<14 # Rich 12 is the last version supporting Python 3.6
 httpx>=0.22.0
 pcpp>=1.2,<2
 zstandard>=0.19.0,<1
+truststore>=0.9.1

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     author="Efabless Corporation",
     author_email="donn@efabless.com",
     install_requires=requirements,
+    extras_require={"truststore": ["truststore"]},  # Python 3.10+
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",

--- a/type_stubs/truststore.pyi
+++ b/type_stubs/truststore.pyi
@@ -1,0 +1,4 @@
+import ssl
+
+class SSLContext(ssl.SSLContext):
+    def __init__(self, protocol: int) -> None: ...

--- a/volare/__main__.py
+++ b/volare/__main__.py
@@ -119,7 +119,7 @@ def rm_cmd(pdk_root, pdk, version):
 @click.command("ls")
 @opt_token
 @opt_pdk_root
-def list_cmd(pdk_root, pdk, session):
+def list_cmd(pdk_root, pdk):
     """Lists PDK versions that are locally installed. JSON if not outputting to a tty."""
 
     pdk_versions = Version.get_all_installed(pdk_root, pdk)
@@ -131,7 +131,6 @@ def list_cmd(pdk_root, pdk, session):
             pdk,
             console=console,
             installed_list=pdk_versions,
-            session=session,
         )
     else:
         print(json.dumps([version.name for version in pdk_versions]), end="")
@@ -140,11 +139,11 @@ def list_cmd(pdk_root, pdk, session):
 @click.command("ls-remote")
 @opt_token
 @opt_pdk_root
-def list_remote_cmd(pdk_root, pdk, session):
+def list_remote_cmd(pdk_root, pdk):
     """Lists PDK versions that are remotely available. JSON if not outputting to a tty."""
 
     try:
-        all_versions = Version._from_github(session)
+        all_versions = Version._from_github()
         pdk_versions = all_versions.get(pdk) or []
 
         if sys.stdout.isatty():
@@ -212,7 +211,6 @@ def enable_cmd(
     tool_metadata_file_path,
     version,
     include_libraries,
-    session,
 ):
     """
     Activates a given installed PDK version.
@@ -240,7 +238,6 @@ def enable_cmd(
             version,
             include_libraries=include_libraries,
             output=console,
-            session=session,
         )
     except Exception as e:
         console.print(f"[red]{e}")
@@ -271,7 +268,6 @@ def fetch_cmd(
     tool_metadata_file_path,
     version,
     include_libraries,
-    session,
 ):
     """
     Fetches a PDK to Volare's store without setting it as the "enabled" version
@@ -300,7 +296,6 @@ def fetch_cmd(
             version=version,
             include_libraries=include_libraries,
             output=console,
-            session=session,
         )
         print(version.get_dir(pdk_root), end="")
 
@@ -337,7 +332,6 @@ def enable_or_build_cmd(
     version,
     use_repo_at,
     push_libraries,
-    session,
 ):
     """
     Attempts to activate a given PDK version. If the version is not found locally or remotely,
@@ -377,7 +371,6 @@ def enable_or_build_cmd(
             },
             include_libraries=include_libraries,
             output=console,
-            session=session,
         )
     except Exception as e:
         console.print(f"[red]{e}")

--- a/volare/__version__.py
+++ b/volare/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.17.0"
+__version__ = "0.18.0"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/volare/build/__init__.py
+++ b/volare/build/__init__.py
@@ -28,8 +28,7 @@ from rich.progress import Progress
 from ..github import (
     GitHubSession,
     get_open_pdks_commit_date,
-    VOLARE_REPO_NAME,
-    VOLARE_REPO_OWNER,
+    volare_repo,
 )
 from ..common import (
     Version,
@@ -101,7 +100,6 @@ def build_cmd(
     tool_metadata_file_path,
     version,
     use_repo_at,
-    session,
 ):
     """
     Builds the requested PDK.
@@ -138,8 +136,8 @@ def push(
     pdk,
     version,
     *,
-    owner=VOLARE_REPO_OWNER,
-    repository=VOLARE_REPO_NAME,
+    owner=volare_repo.owner,
+    repository=volare_repo.name,
     pre=False,
     push_libraries=None,
     session: Optional[GitHubSession] = None,
@@ -244,7 +242,6 @@ def push_cmd(
     pdk,
     version,
     push_libraries,
-    session,
 ):
     """
     For maintainers: Package and release a build to the public.
@@ -263,7 +260,6 @@ def push_cmd(
             repository=repository,
             pre=pre,
             push_libraries=push_libraries,
-            session=session,
         )
     except Exception as e:
         console.print(f"[red]Failed to push version: {e}")

--- a/volare/build/asap7.py
+++ b/volare/build/asap7.py
@@ -108,7 +108,6 @@ def install_asap7(build_directory, pdk_root, version):
     console = Console()
     with console.status("Adding build to list of installed versions…"):
         version_directory = get_version_dir(pdk_root, "asap7", version)
-        print(version_directory)
         if (
             os.path.exists(version_directory)
             and len(os.listdir(version_directory)) != 0

--- a/volare/build/gf180mcu.py
+++ b/volare/build/gf180mcu.py
@@ -28,7 +28,7 @@ from rich.progress import Progress
 from .git_multi_clone import GitMultiClone
 from .common import RepoMetadata, patch_open_pdks
 from ..families import Family
-from ..github import OPDKS_REPO_HTTPS
+from ..github import opdks_repo
 from ..common import (
     get_version_dir,
     get_volare_dir,
@@ -37,7 +37,7 @@ from ..common import (
 
 repo_metadata = {
     "open_pdks": RepoMetadata(
-        OPDKS_REPO_HTTPS,
+        opdks_repo.link,
         "cc0029b45c68137aa21323912f50d2fc17eeea13",
         "master",
     ),

--- a/volare/build/sky130.py
+++ b/volare/build/sky130.py
@@ -29,7 +29,7 @@ from rich.progress import Progress
 from .git_multi_clone import GitMultiClone
 from .common import RepoMetadata, patch_open_pdks
 from ..families import Family
-from ..github import OPDKS_REPO_HTTPS
+from ..github import opdks_repo
 from ..common import (
     get_version_dir,
     get_volare_dir,
@@ -38,7 +38,7 @@ from ..common import (
 
 repo_metadata = {
     "open_pdks": RepoMetadata(
-        OPDKS_REPO_HTTPS,
+        opdks_repo.link,
         "34eeb2743e99d44a21c2cedd467675a2e0f3bb91",
         "master",
     ),

--- a/volare/click_common.py
+++ b/volare/click_common.py
@@ -18,7 +18,7 @@ from typing import Callable, Optional
 import click
 
 from .common import VOLARE_RESOLVED_HOME
-from .github import VOLARE_REPO_OWNER, VOLARE_REPO_NAME, GitHubSession
+from .github import volare_repo, GitHubSession
 
 opt = partial(click.option, show_default=True)
 
@@ -77,10 +77,10 @@ def opt_build(function: Callable):
 
 
 def opt_push(function: Callable):
-    function = opt("-o", "--owner", default=VOLARE_REPO_OWNER, help="Repository Owner")(
+    function = opt("-o", "--owner", default=volare_repo.owner, help="Repository Owner")(
         function
     )
-    function = opt("-r", "--repository", default=VOLARE_REPO_NAME, help="Repository")(
+    function = opt("-r", "--repository", default=volare_repo.name, help="Repository")(
         function
     )
     function = opt(
@@ -102,7 +102,7 @@ def set_token_cb(
     param: click.Parameter,
     value: Optional[str],
 ):
-    return GitHubSession(github_token=value)
+    GitHubSession.Token.override = value
 
 
 def opt_token(function: Callable) -> Callable:
@@ -112,6 +112,7 @@ def opt_token(function: Callable) -> Callable:
         "session",
         default=None,
         required=False,
+        expose_value=False,
         help="Replace the GitHub token used for GitHub requests, which is by default the value of the environment variable GITHUB_TOKEN or None.",
         callback=set_token_cb,
     )(function)

--- a/volare/github.py
+++ b/volare/github.py
@@ -12,70 +12,136 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import json
+import sys
+from datetime import datetime
+from dataclasses import dataclass
+from typing import Any, ClassVar, List, Literal, Mapping, Optional
+
 import yaml
 import httpx
-from datetime import datetime
-from typing import Any, List, Mapping, Optional
-
+import ssl
 from .__version__ import __version__
 
 
-VOLARE_REPO_OWNER = os.getenv("VOLARE_REPO_OWNER") or "efabless"
-VOLARE_REPO_NAME = os.getenv("VOLARE_REPO_NAME") or "volare"
-VOLARE_REPO_ID = f"{VOLARE_REPO_OWNER}/{VOLARE_REPO_NAME}"
-VOLARE_REPO_HTTPS = f"https://github.com/{VOLARE_REPO_ID}"
-VOLARE_REPO_API = f"https://api.github.com/repos/{VOLARE_REPO_ID}"
+@dataclass
+class RepoInfo:
+    owner: str
+    name: str
+
+    @property
+    def id(self):
+        return f"{self.owner}/{self.name}"
+
+    @property
+    def link(self):
+        return f"https://github.com/{self.id}"
+
+    @property
+    def api(self):
+        return f"https://api.github.com/repos/{self.id}"
 
 
-OPDKS_REPO_OWNER = os.getenv("OPDKS_REPO_OWNER") or "RTimothyEdwards"
-OPDKS_REPO_NAME = os.getenv("OPDKS_REPO_NAME") or "open_pdks"
-OPDKS_REPO_ID = f"{OPDKS_REPO_OWNER}/{OPDKS_REPO_NAME}"
-OPDKS_REPO_HTTPS = f"https://github.com/{OPDKS_REPO_ID}"
-OPDKS_REPO_API = f"https://api.github.com/repos/{OPDKS_REPO_ID}"
+volare_repo = RepoInfo(
+    os.getenv("VOLARE_REPO_OWNER") or "efabless",
+    os.getenv("VOLARE_REPO_NAME") or "volare",
+)
+
+opdks_repo = RepoInfo(
+    os.getenv("OPDKS_REPO_OWNER") or "RTimothyEdwards",
+    os.getenv("OPDKS_REPO_NAME") or "open_pdks",
+)
 
 
-def _get_gh_token() -> Optional[str]:
-    token = None
+class Token:
+    override: ClassVar[Optional[str]] = None
 
-    # 0. Lowest priority: ghcli's hosts.yml
-    ghcli_file = os.path.join(os.path.expanduser("~/.config/gh/hosts.yml"))
-    if os.path.exists(ghcli_file):
-        hosts = yaml.safe_load(open(ghcli_file))
-        gh_host = hosts.get("github.com")
-        if gh_host is not None:
-            oauth_token = gh_host.get("oauth_token")
-            if oauth_token is not None:
-                token = str(oauth_token)
-
-    # 1. Higher priority: environment GITHUB_TOKEN
-    env_token = os.getenv("GITHUB_TOKEN")
-    if env_token is not None and env_token.strip() != "":
-        token = env_token
-
-    # 2. Highest priority: the -t flag: passed to constructor
-
-    return token
+    @classmethod
+    def set_override_token(Self, override: str):
+        Self.override = override
 
 
 class GitHubSession(httpx.Client):
+    class Token(object):
+        override: ClassVar[Optional[str]] = None
+
+        @classmethod
+        def get_gh_token(Self) -> Optional[str]:
+            token = None
+
+            # 0. Lowest priority: ghcli's hosts.yml
+            ghcli_file = os.path.join(os.path.expanduser("~/.config/gh/hosts.yml"))
+            if os.path.exists(ghcli_file):
+                hosts = yaml.safe_load(open(ghcli_file))
+                gh_host = hosts.get("github.com")
+                if gh_host is not None:
+                    oauth_token = gh_host.get("oauth_token")
+                    if oauth_token is not None:
+                        token = str(oauth_token)
+
+            # 1. Higher priority: environment GITHUB_TOKEN
+            env_token = os.getenv("GITHUB_TOKEN")
+            if env_token is not None and env_token.strip() != "":
+                token = env_token
+
+            # 2. Highest priority: the -t flag
+            if override := Self.override:
+                token = override
+
+            return token
+
     def __init__(
         self,
         *,
         follow_redirects: bool = True,
-        github_token: Optional[str] = _get_gh_token(),
+        github_token: Optional[str] = None,
+        ssl_context=None,
         **kwargs,
     ):
-        # print("Constructed session")
-        # traceback.print_stack()
-        super().__init__(follow_redirects=follow_redirects, **kwargs)
+        if ssl_context is None:
+            try:
+                import truststore
+
+                ssl_context = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            except ImportError:
+                pass
+
+        try:
+            super().__init__(
+                follow_redirects=follow_redirects,
+                verify=ssl_context,
+                **kwargs,
+            )
+        except ValueError as e:
+            if "Unknown scheme for proxy URL" in e.args[0] and "socks://" in e.args[0]:
+                print(
+                    f"Invalid SOCKS proxy: Volare only supports http://, https:// and socks5:// schemes: {e.args[0]}",
+                    file=sys.stderr,
+                )
+                exit(-1)
+            else:
+                raise e from None
         raw_headers = {
             "User-Agent": type(self).get_user_agent(),
         }
         if github_token is not None:
             raw_headers["Authorization"] = f"Bearer {github_token}"
         self.headers = httpx.Headers(raw_headers)
+        if github_token is None:
+            github_token = GitHubSession.Token.get_gh_token()
         self.github_token = github_token
+
+    def api(
+        self,
+        repo: RepoInfo,
+        endpoint: str,
+        method: Literal["get"],
+        *args,
+        **kwargs,
+    ) -> Any:
+        url = repo.api + endpoint
+        req = self.request(method, url, *args, **kwargs)
+        req.raise_for_status()
+        return req.json()
 
     @classmethod
     def get_user_agent(Self) -> str:
@@ -89,13 +155,10 @@ def get_open_pdks_commit_date(
         session = GitHubSession()
 
     try:
-        request = session.get(f"{OPDKS_REPO_API}/commits/{commit}")
-        request.raise_for_status()
+        response = session.api(opdks_repo, f"/commits/{commit}", "get")
     except httpx.HTTPError:
         return None
 
-    response_str = request.content.decode("utf8")
-    response = json.loads(response_str)
     date = response["commit"]["author"]["date"]
     commit_date = datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ")
     return commit_date
@@ -105,10 +168,7 @@ def get_releases(session: Optional[GitHubSession] = None) -> List[Mapping[str, A
     if session is None:
         session = GitHubSession()
 
-    req = session.get(f"{VOLARE_REPO_API}/releases", params={"per_page": 100})
-    req.raise_for_status()
-
-    return req.json()
+    return session.api(volare_repo, "/releases", "get", params={"per_page": 100})
 
 
 def get_release_links(
@@ -117,8 +177,4 @@ def get_release_links(
     if session is None:
         session = GitHubSession()
 
-    release_api_link = f"{VOLARE_REPO_API}/releases/tags/{release}"
-    req = session.get(release_api_link)
-    req.raise_for_status()
-
-    return req.json()
+    return session.api(volare_repo, f"/releases/tags/{release}", "get")


### PR DESCRIPTION
* SSL verification can optionally computer's default trust store instead of the default `certifi` when `truststore` is installed (always installed with Nix)
* Volare now supports `socks5://` (and only 5) scheme proxies, intercepting the cryptic `ValueError` for `socks://` schemes
* Token is now set globally and not used to create a session that is then passed around
* Slight code structure cleanup