### PR TITLE
Prevent missing github authentication directories from stopping downloading PDKs

### DIFF
--- a/volare/github.py
+++ b/volare/github.py
@@ -75,6 +75,8 @@ class GitHubSession(httpx.Client):
                     ],
                     encoding="utf8",
                 ).strip()
+            except NotADirectoryError:
+                pass
             except FileNotFoundError:
                 pass
             except subprocess.CalledProcessError:


### PR DESCRIPTION
When running volare with the following command (following a fresh install):

`./venv/bin/volare enable --pdk sky130`

I get the following error:

`[Errno 20] Not a directory: 'gh'`

If github authentication information cannot be found, this causes the pdk to never be downloaded. The following fix catches this error.